### PR TITLE
Introduce basic client infrastructure and MealieClient

### DIFF
--- a/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/model/ErrorResponseJson.kt
+++ b/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/model/ErrorResponseJson.kt
@@ -1,0 +1,50 @@
+package com.saintpatrck.mealie.client.api.model
+
+import com.saintpatrck.mealie.client.infrastructure.serializer.ErrorResponseJsonSerializer
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Represents an error response from the Mealie API.
+ */
+@Serializable(with = ErrorResponseJsonSerializer::class)
+sealed class ErrorResponseJson {
+
+    /**
+     * Represents a short error response from the Mealie API.
+     *
+     * @property detail The error message.
+     */
+    @Serializable
+    data class ShortError(
+        @SerialName("detail")
+        val detail: String,
+    ) : ErrorResponseJson()
+
+    /**
+     * Represents a detailed error response from the Mealie API.
+     */
+    @Serializable
+    data class DetailedError(
+        @SerialName("detail")
+        val detail: List<ErrorDetail>,
+    ) : ErrorResponseJson() {
+
+        /**
+         * Represents an error detail from the Mealie API.
+         *
+         * @property location The location of the error.
+         * @property message The error message.
+         * @property type The type of the error.
+         */
+        @Serializable
+        data class ErrorDetail(
+            @SerialName("loc")
+            val location: List<String>,
+            @SerialName("msg")
+            val message: String,
+            @SerialName("type")
+            val type: String,
+        )
+    }
+}

--- a/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/model/MealieBearerTokens.kt
+++ b/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/model/MealieBearerTokens.kt
@@ -1,0 +1,12 @@
+package com.saintpatrck.mealie.client.api.model
+
+/**
+ * Represents a set of bearer tokens for authentication.
+ *
+ * @property accessToken The access token.
+ * @property refreshToken The refresh token.
+ */
+data class MealieBearerTokens(
+    val accessToken: String,
+    val refreshToken: String?,
+)

--- a/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/infrastructure/converter/MealieResponseConverterFactory.kt
+++ b/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/infrastructure/converter/MealieResponseConverterFactory.kt
@@ -1,0 +1,53 @@
+package com.saintpatrck.mealie.client.infrastructure.converter
+
+import com.saintpatrck.mealie.client.api.model.MealieResponse
+import de.jensklingenberg.ktorfit.Ktorfit
+import de.jensklingenberg.ktorfit.converter.Converter
+import de.jensklingenberg.ktorfit.converter.KtorfitResult
+import de.jensklingenberg.ktorfit.converter.TypeData
+import io.ktor.client.call.body
+import io.ktor.client.statement.HttpResponse
+
+/**
+ * Converter factory responsible for providing converters to convert [HttpResponse] into a
+ * [MealieResponse].
+ */
+internal object MealieResponseConverterFactory : Converter.Factory {
+    override fun suspendResponseConverter(
+        typeData: TypeData,
+        ktorfit: Ktorfit,
+    ): Converter.SuspendResponseConverter<HttpResponse, *>? {
+        if (typeData.typeInfo.type == MealieResponse::class) {
+            return object : Converter.SuspendResponseConverter<HttpResponse, Any> {
+                override suspend fun convert(result: KtorfitResult): Any {
+                    return when (result) {
+                        is KtorfitResult.Failure -> {
+                            MealieResponse.error(result.throwable)
+                        }
+
+                        is KtorfitResult.Success -> {
+                            if (result.response.status.value in 200..299) {
+                                MealieResponse.success(
+                                    data = result
+                                        .response
+                                        .call
+                                        .body(typeData.typeArgs.first().typeInfo)
+                                )
+                            } else {
+                                try {
+                                    MealieResponse.failure(
+                                        code = result.response.status.value,
+                                        error = result.response.call.body(),
+                                    )
+                                } catch (e: Exception) {
+                                    MealieResponse.error(e)
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        return null
+    }
+}

--- a/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/infrastructure/ktorfit/MealieKtorfit.kt
+++ b/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/infrastructure/ktorfit/MealieKtorfit.kt
@@ -1,0 +1,92 @@
+package com.saintpatrck.mealie.client.infrastructure.ktorfit
+
+import com.saintpatrck.mealie.client.api.model.MealieBearerTokens
+import com.saintpatrck.mealie.client.infrastructure.converter.MealieResponseConverterFactory
+import com.saintpatrck.mealie.client.platform
+import com.saintpatrck.mealie.client.provider.MealieTokenProvider
+import de.jensklingenberg.ktorfit.Ktorfit
+import de.jensklingenberg.ktorfit.ktorfit
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.HttpClientEngine
+import io.ktor.client.plugins.HttpSend
+import io.ktor.client.plugins.auth.Auth
+import io.ktor.client.plugins.auth.providers.BearerTokens
+import io.ktor.client.plugins.auth.providers.bearer
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.plugins.logging.Logging
+import io.ktor.client.plugins.logging.LoggingConfig
+import io.ktor.client.plugins.plugin
+import io.ktor.serialization.kotlinx.json.json
+import kotlinx.serialization.json.Json
+
+/**
+ * Creates a new [Ktorfit] instance for the Mealie API.
+ *
+ * @param baseUrlProvider The provider for the base URL.
+ * @param mealieTokenProvider The provider for the Mealie tokens.
+ * @param engine The [HttpClientEngine] to use.
+ * @param loggingConfig The logging configuration.
+ */
+internal fun mealieKtorfit(
+    baseUrlProvider: () -> String,
+    mealieTokenProvider: MealieTokenProvider?,
+    engine: HttpClientEngine = platform.httpClientEngineConfig,
+    loggingConfig: (LoggingConfig.() -> Unit) = { },
+) = ktorfit {
+    baseUrl(baseUrlProvider())
+    httpClient(
+        client = HttpClient(engine) {
+            install(plugin = Auth) {
+                bearer {
+                    loadTokens {
+                        mealieTokenProvider
+                            ?.getMealieBearerTokens()
+                            ?.toBearerTokens()
+                    }
+                    refreshTokens {
+                        mealieTokenProvider
+                            ?.refreshMealieBearerTokens(
+                                oldTokens = oldTokens.toMealieTokensOrNull()
+                            )
+                            ?.toBearerTokens()
+                    }
+                }
+            }
+            install(plugin = ContentNegotiation) {
+                json(
+                    Json {
+                        isLenient = true
+                        ignoreUnknownKeys = true
+                    }
+                )
+            }
+            install(plugin = Logging) { loggingConfig(this) }
+            converterFactories(
+                converters = arrayOf(
+                    MealieResponseConverterFactory,
+                ),
+            )
+        }
+            .also { client ->
+                client
+                    .plugin(HttpSend)
+                    .intercept { request ->
+                        execute(
+                            request.apply { url.host = baseUrlProvider() }
+                        )
+                    }
+            }
+    )
+}
+
+private fun MealieBearerTokens.toBearerTokens(): BearerTokens =
+    BearerTokens(accessToken, refreshToken)
+
+private fun BearerTokens?.toMealieTokensOrNull(): MealieBearerTokens? =
+    this
+        ?.let {
+            MealieBearerTokens(
+                accessToken = it.accessToken,
+                refreshToken = it.refreshToken,
+            )
+        }

--- a/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/infrastructure/serializer/ErrorResponseJsonSerializer.kt
+++ b/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/infrastructure/serializer/ErrorResponseJsonSerializer.kt
@@ -1,0 +1,27 @@
+package com.saintpatrck.mealie.client.infrastructure.serializer
+
+import com.saintpatrck.mealie.client.api.model.ErrorResponseJson
+import kotlinx.serialization.DeserializationStrategy
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonContentPolymorphicSerializer
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.jsonObject
+
+/**
+ * Serializer for [ErrorResponseJson].
+ */
+internal object ErrorResponseJsonSerializer :
+    JsonContentPolymorphicSerializer<ErrorResponseJson>(ErrorResponseJson::class) {
+    override fun selectDeserializer(
+        element: JsonElement,
+    ): DeserializationStrategy<ErrorResponseJson> {
+        val jsonObject = element.jsonObject
+        return when {
+            jsonObject["detail"] is JsonPrimitive -> ErrorResponseJson.ShortError.serializer()
+            jsonObject["detail"] is JsonArray -> ErrorResponseJson.DetailedError.serializer()
+            else -> throw SerializationException("Unknown error response format: $jsonObject")
+        }
+    }
+}

--- a/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/model/MealieClientConfig.kt
+++ b/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/model/MealieClientConfig.kt
@@ -1,0 +1,55 @@
+package com.saintpatrck.mealie.client.model
+
+import com.saintpatrck.mealie.client.MealieClient
+import com.saintpatrck.mealie.client.api.model.MealieBearerTokens
+import com.saintpatrck.mealie.client.platform
+import com.saintpatrck.mealie.client.provider.MealieBaseUrlProvider
+import com.saintpatrck.mealie.client.provider.MealieTokenProvider
+import io.ktor.client.engine.HttpClientEngine
+import io.ktor.client.plugins.logging.LoggingConfig
+
+/**
+ * Represents a configuration for the [MealieClient].
+ */
+class MealieClientConfig {
+    /**
+     * The engine used by the client.
+     */
+    var engine: HttpClientEngine = platform.httpClientEngineConfig
+
+    /**
+     * Provides the base URL to use for API requests.
+     */
+    var baseUrlProvider: MealieBaseUrlProvider? = null
+
+    /**
+     * Provides the access tokens to use for API requests.
+     */
+    var accessTokenProvider: () -> MealieBearerTokens? = { null }
+
+    /**
+     * Provides the refresh tokens to use for API requests.
+     */
+    var refreshTokenProvider: suspend (oldTokens: MealieBearerTokens?) -> MealieBearerTokens? =
+        { null }
+    private var mealieTokenProvider: MealieTokenProvider? = null
+    internal var loggingConfig: LoggingConfig.() -> Unit = { }
+        private set
+
+    fun mealieTokenProvider(
+        accessTokens: () -> MealieBearerTokens,
+        refreshTokens: (oldTokens: MealieBearerTokens?) -> MealieBearerTokens?,
+    ) {
+        mealieTokenProvider = object : MealieTokenProvider {
+            override fun getMealieBearerTokens() = accessTokens()
+
+            override suspend fun refreshMealieBearerTokens(
+                oldTokens: MealieBearerTokens?,
+            ) = refreshTokens(oldTokens)
+        }
+    }
+
+    fun loggingConfig(config: LoggingConfig.() -> Unit) {
+        loggingConfig = config
+    }
+}

--- a/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/provider/MealieBaseUrlProvider.kt
+++ b/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/provider/MealieBaseUrlProvider.kt
@@ -1,0 +1,11 @@
+package com.saintpatrck.mealie.client.provider
+
+/**
+ * Provides the base URL for the Mealie API.
+ */
+interface MealieBaseUrlProvider {
+    /**
+     * The base URL for the Mealie API.
+     */
+    val baseUrl: String
+}

--- a/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/provider/MealieTokenProvider.kt
+++ b/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/provider/MealieTokenProvider.kt
@@ -1,0 +1,21 @@
+package com.saintpatrck.mealie.client.provider
+
+import com.saintpatrck.mealie.client.api.model.MealieBearerTokens
+
+/**
+ * Represents a provider of Mealie bearer tokens.
+ */
+interface MealieTokenProvider {
+    /**
+     * Gets the Mealie bearer tokens.
+     */
+    fun getMealieBearerTokens(): MealieBearerTokens?
+
+    /**
+     * Refreshes the Mealie bearer tokens.
+     *
+     * @param oldTokens The old Mealie bearer tokens.
+     * @return The refreshed Mealie bearer tokens.
+     */
+    suspend fun refreshMealieBearerTokens(oldTokens: MealieBearerTokens?): MealieBearerTokens?
+}

--- a/client/src/commonTest/kotlin/com/saintpatrck/mealie/client/api/base/BaseApiTest.kt
+++ b/client/src/commonTest/kotlin/com/saintpatrck/mealie/client/api/base/BaseApiTest.kt
@@ -1,0 +1,70 @@
+package com.saintpatrck.mealie.client.api.base
+
+import com.saintpatrck.mealie.client.api.model.MealieBearerTokens
+import com.saintpatrck.mealie.client.mealieClient
+import com.saintpatrck.mealie.client.provider.MealieBaseUrlProvider
+import com.saintpatrck.mealie.client.provider.MealieTokenProvider
+import createMockEngine
+import io.ktor.client.plugins.logging.LogLevel
+import io.ktor.client.plugins.logging.Logger
+import io.ktor.http.Headers
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+
+/**
+ * Base class for Ktorfit tests.
+ */
+abstract class BaseApiTest {
+
+    var urlProvider = object : MealieBaseUrlProvider {
+        override val baseUrl: String = "http://localhost:9925/"
+    }
+
+    var mealieTokenProvider = object : MealieTokenProvider {
+        override fun getMealieBearerTokens(): MealieBearerTokens? {
+            return MealieBearerTokens("accessToken", "refreshToken")
+        }
+
+        override suspend fun refreshMealieBearerTokens(oldTokens: MealieBearerTokens?): MealieBearerTokens? {
+            return MealieBearerTokens("accessToken", "refreshToken")
+        }
+    }
+
+    val mealieClientLogger = object : Logger {
+        override fun log(message: String) {
+            println(message)
+        }
+    }
+
+    fun createTestMealieClient(
+        responseJson: String,
+        status: HttpStatusCode = HttpStatusCode.OK,
+        headers: Headers = headersOf(HttpHeaders.ContentType, "application/json"),
+    ) = mealieClient {
+        engine = createMockEngine(
+            response = responseJson,
+            status = status,
+            headers = headers,
+        )
+        baseUrlProvider = urlProvider
+        accessTokenProvider = {
+            mealieTokenProvider.getMealieBearerTokens()
+        }
+        refreshTokenProvider = { oldTokens ->
+            mealieTokenProvider.refreshMealieBearerTokens(oldTokens)
+        }
+        mealieTokenProvider(
+            accessTokens = {
+                MealieBearerTokens("accessToken", "refreshToken")
+            },
+            refreshTokens = {
+                MealieBearerTokens("accessToken", "refreshToken")
+            }
+        )
+        loggingConfig {
+            logger = mealieClientLogger
+            level = LogLevel.ALL
+        }
+    }
+}

--- a/client/src/commonTest/kotlin/com/saintpatrck/mealie/client/infrastructure/util/HttpClientEngineUtils.kt
+++ b/client/src/commonTest/kotlin/com/saintpatrck/mealie/client/infrastructure/util/HttpClientEngineUtils.kt
@@ -1,0 +1,23 @@
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.http.Headers
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+
+/**
+ * Creates a mock engine for testing purposes.
+ */
+fun createMockEngine(
+    response: String,
+    status: HttpStatusCode = HttpStatusCode.OK,
+    headers: Headers = headersOf(HttpHeaders.ContentType, "application/json"),
+): MockEngine {
+    return MockEngine { request ->
+        respond(
+            content = response,
+            status = status,
+            headers = headers
+        )
+    }
+}


### PR DESCRIPTION
This commit introduces the foundational infrastructure for the Mealie client, including:

- `MealieClientConfig`: Configuration for the Mealie client.
- `MealieBaseUrlProvider`: Interface for providing the base URL.
- `MealieTokenProvider`: Interface for providing authentication tokens.
- `MealieBearerTokens`: Data class for bearer tokens.
- `ErrorResponseJson`: Sealed class for representing API error responses and a custom serializer.
- `MealieResponseConverterFactory`: Ktorfit converter factory for handling `MealieResponse`.
- `MealieKtorfit`: Internal function to configure Ktorfit with Mealie-specific settings.
- `MealieClient`: The main client class for interacting with the Mealie API, exposing `aboutApi` and `authApi`.

Additionally, base test classes and utilities are added:
- `BaseApiTest`: Base class for API tests.
- `createMockEngine`: Utility function for creating mock HTTP engines.