### PR TITLE
Include agp and ksp in platform Renovate group

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -43,6 +43,8 @@
         '/com.android.application/',
         '/com.android.library/',
         '/org.jetbrains.kotlin.*/',
+        '/com.google.devtools.ksp/',
+        '/com.android.tools.build.gradle/'
       ],
     },
     {


### PR DESCRIPTION
This pull request updates the Renovate configuration to include additional Gradle plugin patterns for dependency updates.

Configuration updates:

* [`.github/renovate.json5`](diffhunk://#diff-20ab1190d08a53a3012bc191ed56205c8f0ffb8fa1715e9d36ecfd1d2ea8a790R46-R47): Added support for the `com.google.devtools.ksp` and `com.android.tools.build.gradle` plugin patterns to ensure these dependencies are tracked and updated together.