### PR TITLE
Add About API and error response serializer tests

### DIFF
--- a/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/MealieClient.kt
+++ b/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/MealieClient.kt
@@ -1,5 +1,7 @@
 package com.saintpatrck.mealie.client
 
+import com.saintpatrck.mealie.client.api.about.AboutApi
+import com.saintpatrck.mealie.client.api.about.createAboutApi
 import com.saintpatrck.mealie.client.api.model.MealieBearerTokens
 import com.saintpatrck.mealie.client.infrastructure.ktorfit.mealieKtorfit
 import com.saintpatrck.mealie.client.model.MealieClientConfig
@@ -41,5 +43,12 @@ class MealieClient internal constructor(
                 apply(mealieClientConfig.loggingConfig)
             },
         )
+    }
+
+    /**
+     * The API for retrieving information about the Mealie instance.
+     */
+    val aboutApi: AboutApi by lazy {
+        ktorfit.createAboutApi()
     }
 }

--- a/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/about/AboutApi.kt
+++ b/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/about/AboutApi.kt
@@ -1,0 +1,31 @@
+package com.saintpatrck.mealie.client.api.about
+
+import com.saintpatrck.mealie.client.api.about.model.AppInfoResponseJson
+import com.saintpatrck.mealie.client.api.about.model.AppThemeResponseJson
+import com.saintpatrck.mealie.client.api.about.model.StartupInfoResponseJson
+import com.saintpatrck.mealie.client.api.model.MealieResponse
+import de.jensklingenberg.ktorfit.http.GET
+
+/**
+ * Represents the API for retrieving information about the app.
+ */
+interface AboutApi {
+
+    /**
+     * Retrieves information about the app.
+     */
+    @GET("app/about")
+    suspend fun aboutApp(): MealieResponse<AppInfoResponseJson>
+
+    /**
+     * Retrieves startup information of the app.
+     */
+    @GET("app/about/startup-info")
+    suspend fun startupInfo(): MealieResponse<StartupInfoResponseJson>
+
+    /**
+     * Retrieves the theme of the app.
+     */
+    @GET("app/about/theme")
+    suspend fun theme(): MealieResponse<AppThemeResponseJson>
+}

--- a/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/about/model/AppInfoResponseJson.kt
+++ b/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/about/model/AppInfoResponseJson.kt
@@ -1,0 +1,43 @@
+package com.saintpatrck.mealie.client.api.about.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Represents the response from the /app/about endpoint.
+ */
+@Serializable
+data class AppInfoResponseJson(
+    @SerialName("production")
+    val production: Boolean,
+
+    @SerialName("version")
+    val version: String,
+
+    @SerialName("demoStatus")
+    val demoStatus: Boolean,
+
+    @SerialName("allowSignup")
+    val allowSignup: Boolean,
+
+    @SerialName("enableOidc")
+    val enableOidc: Boolean,
+
+    @SerialName("oidcRedirect")
+    val oidcRedirect: Boolean,
+
+    @SerialName("oidcProviderName")
+    val oidcProviderName: String,
+
+    @SerialName("enableOpenai")
+    val enableOpenai: Boolean,
+
+    @SerialName("enableOpenaiImageServices")
+    val enableOpenaiImageServices: Boolean,
+
+    @SerialName("defaultGroupSlug")
+    val defaultGroupSlug: String? = null,
+
+    @SerialName("defaultHouseholdSlug")
+    val defaultHouseholdSlug: String? = null,
+)

--- a/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/about/model/AppThemeResponseJson.kt
+++ b/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/about/model/AppThemeResponseJson.kt
@@ -1,0 +1,52 @@
+package com.saintpatrck.mealie.client.api.about.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Represents the response of the app/about/theme endpoint.
+ */
+@Serializable
+data class AppThemeResponseJson(
+    @SerialName("lightPrimary")
+    val lightPrimary: String,
+
+    @SerialName("lightAccent")
+    val lightAccent: String,
+
+    @SerialName("lightSecondary")
+    val lightSecondary: String,
+
+    @SerialName("lightSuccess")
+    val lightSuccess: String,
+
+    @SerialName("lightInfo")
+    val lightInfo: String,
+
+    @SerialName("lightWarning")
+    val lightWarning: String,
+
+    @SerialName("lightError")
+    val lightError: String,
+
+    @SerialName("darkPrimary")
+    val darkPrimary: String,
+
+    @SerialName("darkAccent")
+    val darkAccent: String,
+
+    @SerialName("darkSecondary")
+    val darkSecondary: String,
+
+    @SerialName("darkSuccess")
+    val darkSuccess: String,
+
+    @SerialName("darkInfo")
+    val darkInfo: String,
+
+    @SerialName("darkWarning")
+    val darkWarning: String,
+
+    @SerialName("darkError")
+    val darkError: String,
+)

--- a/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/about/model/StartupInfoResponseJson.kt
+++ b/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/about/model/StartupInfoResponseJson.kt
@@ -1,0 +1,16 @@
+package com.saintpatrck.mealie.client.api.about.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Represents a response from the app/about/startup-info endpoint.
+ */
+@Serializable
+data class StartupInfoResponseJson(
+    @SerialName("isFirstLogin")
+    val isFirstLogin: Boolean,
+
+    @SerialName("isDemo")
+    val isDemo: Boolean,
+)

--- a/client/src/commonTest/kotlin/com/saintpatrck/mealie/client/api/about/AboutApiTest.kt
+++ b/client/src/commonTest/kotlin/com/saintpatrck/mealie/client/api/about/AboutApiTest.kt
@@ -1,0 +1,167 @@
+package com.saintpatrck.mealie.client.api.about
+
+import com.saintpatrck.mealie.client.api.about.model.AppInfoResponseJson
+import com.saintpatrck.mealie.client.api.about.model.AppThemeResponseJson
+import com.saintpatrck.mealie.client.api.about.model.StartupInfoResponseJson
+import com.saintpatrck.mealie.client.api.base.BaseApiTest
+import com.saintpatrck.mealie.client.api.model.getOrNull
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class AboutApiTest : BaseApiTest() {
+
+    @Test
+    fun `aboutApp should return success with data`() = runTest {
+        createTestMealieClient(
+            responseJson = ABOUT_RESPONSE_JSON,
+        )
+            .aboutApi
+            .aboutApp()
+            .also { response ->
+                assertEquals(
+                    createMockAppInfoResponseJson(),
+                    response.getOrNull(),
+                )
+            }
+    }
+
+    @Test
+    fun `startupInfo should return success with data`() = runTest {
+        createTestMealieClient(
+            responseJson = STARTUP_INFO_RESPONSE_JSON,
+        )
+            .aboutApi
+            .startupInfo()
+            .also { response ->
+                assertEquals(
+                    createMockStartupInfoResponseJson(),
+                    response.getOrNull(),
+                )
+            }
+    }
+
+    @Test
+    fun `theme should return success with data`() = runTest {
+        createTestMealieClient(
+            responseJson = THEME_RESPONSE_JSON,
+        )
+            .aboutApi
+            .theme()
+            .also { response ->
+                assertEquals(
+                    createMockThemeResponseJson(),
+                    response.getOrNull(),
+                )
+            }
+    }
+}
+
+private val ABOUT_RESPONSE_JSON = """
+{
+    "production": true,
+    "version": "string",
+    "demoStatus": true,
+    "allowSignup": true,
+    "defaultGroupSlug": "string",
+    "defaultHouseholdSlug": "string",
+    "enableOidc": true,
+    "oidcRedirect": true,
+    "oidcProviderName": "string",
+    "enableOpenai": true,
+    "enableOpenaiImageServices": true
+}
+"""
+    .trimIndent()
+private val THEME_RESPONSE_JSON = """
+{
+  "lightPrimary": "#000000",
+  "lightAccent": "#007A99",
+  "lightSecondary": "#973542",
+  "lightSuccess": "#43A047",
+  "lightInfo": "#1976D2",
+  "lightWarning": "#FF6D00",
+  "lightError": "#EF5350",
+  "darkPrimary": "#E58325",
+  "darkAccent": "#007A99",
+  "darkSecondary": "#973542",
+  "darkSuccess": "#43A047",
+  "darkInfo": "#1976D2",
+  "darkWarning": "#FF6D00",
+  "darkError": "#EF5350"
+}
+"""
+    .trimIndent()
+private val STARTUP_INFO_RESPONSE_JSON = """
+{
+    "isFirstLogin": true,
+    "isDemo": true
+}
+"""
+    .trimIndent()
+
+private fun createMockAppInfoResponseJson(
+    production: Boolean = true,
+    version: String = "string",
+    demoStatus: Boolean = true,
+    allowSignup: Boolean = true,
+    defaultGroupSlug: String = "string",
+    defaultHouseholdSlug: String = "string",
+    enableOidc: Boolean = true,
+    oidcRedirect: Boolean = true,
+    oidcProviderName: String = "string",
+    enableOpenai: Boolean = true,
+    enableOpenaiImageServices: Boolean = true,
+): AppInfoResponseJson = AppInfoResponseJson(
+    production = production,
+    version = version,
+    demoStatus = demoStatus,
+    allowSignup = allowSignup,
+    defaultGroupSlug = defaultGroupSlug,
+    defaultHouseholdSlug = defaultHouseholdSlug,
+    enableOidc = enableOidc,
+    oidcRedirect = oidcRedirect,
+    oidcProviderName = oidcProviderName,
+    enableOpenai = enableOpenai,
+    enableOpenaiImageServices = enableOpenaiImageServices,
+)
+
+private fun createMockStartupInfoResponseJson(
+    isFirstLogin: Boolean = true,
+    isDemo: Boolean = true,
+) = StartupInfoResponseJson(
+    isFirstLogin = isFirstLogin,
+    isDemo = isDemo,
+)
+
+private fun createMockThemeResponseJson(
+    lightPrimary: String = "#000000",
+    lightAccent: String = "#007A99",
+    lightSecondary: String = "#973542",
+    lightSuccess: String = "#43A047",
+    lightInfo: String = "#1976D2",
+    lightWarning: String = "#FF6D00",
+    lightError: String = "#EF5350",
+    darkPrimary: String = "#E58325",
+    darkAccent: String = "#007A99",
+    darkSecondary: String = "#973542",
+    darkSuccess: String = "#43A047",
+    darkInfo: String = "#1976D2",
+    darkWarning: String = "#FF6D00",
+    darkError: String = "#EF5350",
+) = AppThemeResponseJson(
+    lightPrimary = lightPrimary,
+    lightAccent = lightAccent,
+    lightSecondary = lightSecondary,
+    lightSuccess = lightSuccess,
+    lightInfo = lightInfo,
+    lightWarning = lightWarning,
+    lightError = lightError,
+    darkPrimary = darkPrimary,
+    darkAccent = darkAccent,
+    darkSecondary = darkSecondary,
+    darkSuccess = darkSuccess,
+    darkInfo = darkInfo,
+    darkWarning = darkWarning,
+    darkError = darkError,
+)


### PR DESCRIPTION
This commit introduces the `AboutApi` for retrieving information about the Mealie instance. It includes endpoints for `/app/about`, `/app/about/startup-info`, and `/app/about/theme`.