### PR TITLE
Add AuthApi with tests and model classes

### DIFF
--- a/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/MealieClient.kt
+++ b/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/MealieClient.kt
@@ -2,6 +2,8 @@ package com.saintpatrck.mealie.client
 
 import com.saintpatrck.mealie.client.api.about.AboutApi
 import com.saintpatrck.mealie.client.api.about.createAboutApi
+import com.saintpatrck.mealie.client.api.auth.AuthApi
+import com.saintpatrck.mealie.client.api.auth.createAuthApi
 import com.saintpatrck.mealie.client.api.model.MealieBearerTokens
 import com.saintpatrck.mealie.client.infrastructure.ktorfit.mealieKtorfit
 import com.saintpatrck.mealie.client.model.MealieClientConfig
@@ -16,7 +18,6 @@ fun mealieClient(
 ): MealieClient = MealieClient(
     MealieClientConfig().apply(config)
 )
-
 
 /**
  * Represents a client for the Mealie API.
@@ -50,5 +51,12 @@ class MealieClient internal constructor(
      */
     val aboutApi: AboutApi by lazy {
         ktorfit.createAboutApi()
+    }
+
+    /**
+     * The API for authenticating with the Mealie instance.
+     */
+    val authApi: AuthApi by lazy {
+        ktorfit.createAuthApi()
     }
 }

--- a/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/auth/AuthApi.kt
+++ b/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/auth/AuthApi.kt
@@ -1,0 +1,43 @@
+package com.saintpatrck.mealie.client.api.auth
+
+import com.saintpatrck.mealie.client.api.auth.model.LogoutResponseJson
+import com.saintpatrck.mealie.client.api.auth.model.TokenResponseJson
+import com.saintpatrck.mealie.client.api.model.MealieResponse
+import de.jensklingenberg.ktorfit.http.Field
+import de.jensklingenberg.ktorfit.http.FormUrlEncoded
+import de.jensklingenberg.ktorfit.http.GET
+import de.jensklingenberg.ktorfit.http.POST
+
+/**
+ * Represents the API for retrieving authentication tokens.
+ */
+interface AuthApi {
+
+    /**
+     * Retrieves authentication tokens.
+     */
+    @POST("auth/token")
+    @FormUrlEncoded
+    suspend fun getToken(
+        @Field("username")
+        username: String,
+
+        @Field("password")
+        password: String,
+
+        @Field("remember_me")
+        rememberMe: Boolean,
+    ): MealieResponse<TokenResponseJson>
+
+    /**
+     * Refreshes the authentication tokens.
+     */
+    @GET("auth/refresh")
+    suspend fun refreshToken(): MealieResponse<TokenResponseJson>
+
+    /**
+     * Logs out the user.
+     */
+    @POST("auth/logout")
+    suspend fun logout(): MealieResponse<LogoutResponseJson>
+}

--- a/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/auth/model/LogoutResponseJson.kt
+++ b/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/auth/model/LogoutResponseJson.kt
@@ -1,0 +1,13 @@
+package com.saintpatrck.mealie.client.api.auth.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Represents a response from the logout endpoint.
+ */
+@Serializable
+data class LogoutResponseJson(
+    @SerialName("message")
+    val message: String,
+)

--- a/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/auth/model/TokenResponseJson.kt
+++ b/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/auth/model/TokenResponseJson.kt
@@ -1,0 +1,16 @@
+package com.saintpatrck.mealie.client.api.auth.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Response from the /auth/token endpoint.
+ */
+@Serializable
+data class TokenResponseJson(
+    @SerialName("access_token")
+    val accessToken: String,
+
+    @SerialName("token_type")
+    val tokenType: String?,
+)

--- a/client/src/commonTest/kotlin/com/saintpatrck/mealie/client/api/auth/AuthApiTest.kt
+++ b/client/src/commonTest/kotlin/com/saintpatrck/mealie/client/api/auth/AuthApiTest.kt
@@ -1,0 +1,84 @@
+package com.saintpatrck.mealie.client.api.auth
+
+import com.saintpatrck.mealie.client.api.auth.model.LogoutResponseJson
+import com.saintpatrck.mealie.client.api.auth.model.TokenResponseJson
+import com.saintpatrck.mealie.client.api.base.BaseApiTest
+import com.saintpatrck.mealie.client.api.model.getOrNull
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class AuthApiTest : BaseApiTest() {
+
+    @Test
+    fun `getToken should return success with data`() = runTest {
+        createTestMealieClient(
+            responseJson = TOKEN_RESPONSE_JSON,
+        )
+            .authApi
+            .getToken(
+                username = "username",
+                password = "password",
+                rememberMe = true,
+            )
+            .also { response ->
+                assertEquals(
+                    createMockTokenResponseJson(),
+                    response.getOrNull(),
+                )
+            }
+    }
+
+    @Test
+    fun `refreshToken should return success with data`() = runTest {
+        createTestMealieClient(
+            responseJson = TOKEN_RESPONSE_JSON,
+        )
+            .authApi
+            .refreshToken()
+            .also { response ->
+                assertEquals(
+                    createMockTokenResponseJson(),
+                    response.getOrNull(),
+                )
+            }
+    }
+
+    @Test
+    fun `logout should return success with data`() = runTest {
+        createTestMealieClient(
+            responseJson = LOGOUT_RESPONSE_JSON,
+        )
+            .authApi
+            .logout()
+            .also { response ->
+                assertEquals(
+                    createMockLogoutResponseJson(),
+                    response.getOrNull(),
+                )
+            }
+    }
+}
+
+private val TOKEN_RESPONSE_JSON = """
+{
+    "access_token": "string",
+    "token_type": "string"
+}
+"""
+    .trimIndent()
+private val LOGOUT_RESPONSE_JSON = """
+{
+    "message": "string"
+}
+"""
+    .trimIndent()
+
+private fun createMockTokenResponseJson() = TokenResponseJson(
+    accessToken = "string",
+    tokenType = "string",
+)
+
+private fun createMockLogoutResponseJson() = LogoutResponseJson(
+    message = "string",
+)

--- a/client/src/commonTest/kotlin/com/saintpatrck/mealie/client/serializer/ErrorResponseJsonSerializerTest.kt
+++ b/client/src/commonTest/kotlin/com/saintpatrck/mealie/client/serializer/ErrorResponseJsonSerializerTest.kt
@@ -1,0 +1,83 @@
+package com.saintpatrck.mealie.client.serializer
+
+import com.saintpatrck.mealie.client.api.base.BaseApiTest
+import com.saintpatrck.mealie.client.api.model.ErrorResponseJson
+import com.saintpatrck.mealie.client.api.model.failureOrNull
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class ErrorResponseJsonSerializerTest : BaseApiTest() {
+    @Test
+    fun `failure with short error should be deserialized correctly`() = runTest {
+        createTestMealieClient(
+            responseJson = SHORT_ERROR_RESPONSE,
+            status = HttpStatusCode.BadRequest,
+            headers = headersOf(HttpHeaders.ContentType, "application/json"),
+        )
+            .authApi
+            .logout()
+            .also { response ->
+                assertEquals(
+                    createMockShortErrorResponseJson(),
+                    response.failureOrNull()?.error,
+                )
+            }
+    }
+
+    @Test
+    fun `failure with detailed error should be deserialized correctly`() = runTest {
+        createTestMealieClient(
+            responseJson = ERROR_RESPONSE,
+            status = HttpStatusCode.BadRequest,
+            headers = headersOf(HttpHeaders.ContentType, "application/json"),
+        )
+            .authApi
+            .logout()
+            .also { response ->
+                assertEquals(
+                    createMockDetailedErrorResponseJson(),
+                    response.failureOrNull()?.error,
+                )
+            }
+    }
+}
+
+private val SHORT_ERROR_RESPONSE = """
+{
+    "detail": "string"
+}
+"""
+    .trimIndent()
+
+private val ERROR_RESPONSE = """
+{
+  "detail": [
+    {
+      "loc": [
+        "string"
+      ],
+      "msg": "string",
+      "type": "string"
+    }
+  ]
+}
+"""
+    .trimIndent()
+
+private fun createMockDetailedErrorResponseJson() = ErrorResponseJson.DetailedError(
+    detail = listOf(
+        ErrorResponseJson.DetailedError.ErrorDetail(
+            location = listOf("string"),
+            message = "string",
+            type = "string",
+        )
+    )
+)
+
+private fun createMockShortErrorResponseJson() = ErrorResponseJson.ShortError(
+    detail = "string",
+)


### PR DESCRIPTION
This commit introduces the `AuthApi` interface and its corresponding model classes: `LogoutResponseJson` and `TokenResponseJson`.

The `AuthApi` provides methods for:
- `getToken`: Retrieves authentication tokens.
- `refreshToken`: Refreshes authentication tokens.
- `logout`: Logs out the user.

Unit tests for `AuthApi` are included in `AuthApiTest.kt` to ensure the correct handling of successful responses.

Additionally, tests for `ErrorResponseJsonSerializer` have been added in `ErrorResponseJsonSerializerTest.kt` to verify the deserialization of short and detailed error responses.