### PR TITLE
Add GitHub Actions workflow for build and test

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,0 +1,55 @@
+name: Build and Test
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request_target:
+    branches: [ "main" ]
+
+jobs:
+  build-and-test:
+    # We only run tests from commonTest, so we can run this job
+    # on ubuntu. If/when iOS tests are added, this will need to
+    # be changed to macos-latest
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          java-version: '18'
+          distribution: 'temurin'
+
+      - name: Set up Android SDK
+        uses: android-actions/setup-android@v3
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x ./gradlew
+
+      - name: Setup Gradle Dependencies Cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      - name: Build project
+        run: ./gradlew build
+
+      - name: Run tests
+        run: ./gradlew check
+
+      - name: Upload Reports
+        if: always() # Run this step even if previous steps fail
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-and-test-reports
+          path: |
+            **/build/reports/
+            **/build/test-results/


### PR DESCRIPTION
This commit introduces a new GitHub Actions workflow named "Build and Test". The workflow is triggered on pushes and pull requests to the "main" branch.

It includes the following steps:
- Checkout code
- Set up JDK 18 (Temurin)
- Set up Android SDK
- Grant execute permission for gradlew
- Cache Gradle dependencies
- Build the project using `./gradlew build`
- Run tests using `./gradlew check`
- Upload build and test reports as artifacts, even if previous steps fail.

The job currently runs on `ubuntu-latest` as only common tests are executed.