### PR TITLE
Refactor ErrorResponseJson for better error handling

### DIFF
--- a/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/model/ErrorResponseJson.kt
+++ b/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/model/ErrorResponseJson.kt
@@ -5,46 +5,76 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 /**
- * Represents an error response from the Mealie API.
+ * Models possible error responses from the Mealie API.
  */
 @Serializable(with = ErrorResponseJsonSerializer::class)
 sealed class ErrorResponseJson {
 
     /**
-     * Represents a short error response from the Mealie API.
+     * Models a short error response from the Mealie API.
      *
      * @property detail The error message.
      */
     @Serializable
-    data class ShortError(
+    data class Unauthorized(
         @SerialName("detail")
         val detail: String,
     ) : ErrorResponseJson()
 
     /**
-     * Represents a detailed error response from the Mealie API.
+     * Models a Validation error response from the Mealie API with multiple errors.
+     *
+     * @property detail The list of validation errors.
      */
     @Serializable
-    data class DetailedError(
+    data class ValidationErrors(
         @SerialName("detail")
-        val detail: List<ErrorDetail>,
+        val detail: List<ValidationError>,
     ) : ErrorResponseJson() {
 
         /**
-         * Represents an error detail from the Mealie API.
+         * Represents a validation error from the Mealie API.
          *
          * @property location The location of the error.
          * @property message The error message.
          * @property type The type of the error.
          */
         @Serializable
-        data class ErrorDetail(
+        data class ValidationError(
             @SerialName("loc")
             val location: List<String>,
             @SerialName("msg")
             val message: String,
             @SerialName("type")
-            val type: String,
+            val type: String?,
+        )
+    }
+
+    /**
+     * Represents a Forbidden error response from the Mealie API.
+     *
+     * @property detail The error detail.
+     */
+    @Serializable
+    data class Forbidden(
+        @SerialName("detail")
+        val detail: Detail,
+    ) : ErrorResponseJson() {
+        /**
+         * Represents the detail of the Forbidden response from the Mealie API.
+         *
+         * @property message The error message.
+         * @property error TODO
+         * @property exception The exception type.
+         */
+        @Serializable
+        data class Detail(
+            @SerialName("message")
+            val message: String,
+            @SerialName("error")
+            val error: Boolean,
+            @SerialName("exception")
+            val exception: String?,
         )
     }
 }

--- a/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/infrastructure/serializer/ErrorResponseJsonSerializer.kt
+++ b/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/infrastructure/serializer/ErrorResponseJsonSerializer.kt
@@ -6,6 +6,7 @@ import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonContentPolymorphicSerializer
 import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.jsonObject
 
@@ -19,8 +20,9 @@ internal object ErrorResponseJsonSerializer :
     ): DeserializationStrategy<ErrorResponseJson> {
         val jsonObject = element.jsonObject
         return when {
-            jsonObject["detail"] is JsonPrimitive -> ErrorResponseJson.ShortError.serializer()
-            jsonObject["detail"] is JsonArray -> ErrorResponseJson.DetailedError.serializer()
+            jsonObject["detail"] is JsonPrimitive -> ErrorResponseJson.Unauthorized.serializer()
+            jsonObject["detail"] is JsonObject -> ErrorResponseJson.Forbidden.serializer()
+            jsonObject["detail"] is JsonArray -> ErrorResponseJson.ValidationErrors.serializer()
             else -> throw SerializationException("Unknown error response format: $jsonObject")
         }
     }

--- a/client/src/commonTest/kotlin/com/saintpatrck/mealie/client/serializer/ErrorResponseJsonSerializerTest.kt
+++ b/client/src/commonTest/kotlin/com/saintpatrck/mealie/client/serializer/ErrorResponseJsonSerializerTest.kt
@@ -12,50 +12,74 @@ import kotlin.test.assertEquals
 
 class ErrorResponseJsonSerializerTest : BaseApiTest() {
     @Test
-    fun `failure with short error should be deserialized correctly`() = runTest {
+    fun `Unauthorized response should be deserialized correctly`() = runTest {
         createTestMealieClient(
-            responseJson = SHORT_ERROR_RESPONSE,
-            status = HttpStatusCode.BadRequest,
+            responseJson = UNAUTHORIZED_ERROR_RESPONSE,
+            status = HttpStatusCode.Unauthorized,
             headers = headersOf(HttpHeaders.ContentType, "application/json"),
         )
             .authApi
             .logout()
             .also { response ->
                 assertEquals(
-                    createMockShortErrorResponseJson(),
+                    createMockUnauthorizedResponseJson(),
                     response.failureOrNull()?.error,
                 )
             }
     }
 
     @Test
-    fun `failure with detailed error should be deserialized correctly`() = runTest {
+    fun `Validation response should be deserialized correctly`() = runTest {
         createTestMealieClient(
-            responseJson = ERROR_RESPONSE,
-            status = HttpStatusCode.BadRequest,
+            responseJson = VALIDATION_ERROR_RESPONSE,
+            status = HttpStatusCode.UnprocessableEntity,
             headers = headersOf(HttpHeaders.ContentType, "application/json"),
         )
             .authApi
             .logout()
             .also { response ->
                 assertEquals(
-                    createMockDetailedErrorResponseJson(),
+                    createMockValidationErrorResponseJson(),
+                    response.failureOrNull()?.error,
+                )
+            }
+    }
+
+    @Test
+    fun `Forbidden response should be deserialized correctly`() = runTest {
+        createTestMealieClient(
+            responseJson = FORBIDDEN_ERROR_RESPONSE,
+            status = HttpStatusCode.Forbidden,
+            headers = headersOf(HttpHeaders.ContentType, "application/json"),
+        )
+            .authApi
+            .logout()
+            .also { response ->
+                assertEquals(
+                    createMockForbiddenResponseJson(),
                     response.failureOrNull()?.error,
                 )
             }
     }
 }
 
-private val SHORT_ERROR_RESPONSE = """
+private val UNAUTHORIZED_ERROR_RESPONSE = """
 {
     "detail": "string"
 }
 """
     .trimIndent()
 
-private val ERROR_RESPONSE = """
+private val VALIDATION_ERROR_RESPONSE = """
 {
   "detail": [
+    {
+      "loc": [
+        "string"
+      ],
+      "msg": "string",
+      "type": "string"
+    },
     {
       "loc": [
         "string"
@@ -68,16 +92,40 @@ private val ERROR_RESPONSE = """
 """
     .trimIndent()
 
-private fun createMockDetailedErrorResponseJson() = ErrorResponseJson.DetailedError(
+private val FORBIDDEN_ERROR_RESPONSE = """
+{
+    "detail": {
+        "message": "string",
+        "error": true,
+        "exception": null
+    }
+}
+"""
+    .trimIndent()
+
+private fun createMockValidationErrorResponseJson() = ErrorResponseJson.ValidationErrors(
     detail = listOf(
-        ErrorResponseJson.DetailedError.ErrorDetail(
+        ErrorResponseJson.ValidationErrors.ValidationError(
             location = listOf("string"),
             message = "string",
             type = "string",
-        )
+        ),
+        ErrorResponseJson.ValidationErrors.ValidationError(
+            location = listOf("string"),
+            message = "string",
+            type = "string",
+        ),
     )
 )
 
-private fun createMockShortErrorResponseJson() = ErrorResponseJson.ShortError(
+private fun createMockUnauthorizedResponseJson() = ErrorResponseJson.Unauthorized(
     detail = "string",
+)
+
+private fun createMockForbiddenResponseJson() = ErrorResponseJson.Forbidden(
+    detail = ErrorResponseJson.Forbidden.Detail(
+        message = "string",
+        error = true,
+        exception = null,
+    )
 )


### PR DESCRIPTION
This commit refactors the `ErrorResponseJson` sealed class to provide more specific error types for common HTTP error codes like 401 (Unauthorized), 403 (Forbidden), and 422 (Unprocessable Entity - Validation Errors).

The `ErrorResponseJsonSerializer` has been updated to correctly deserialize these new error types based on the structure of the "detail" field in the JSON response.

- `ShortError` is renamed to `Unauthorized` to better reflect its purpose.
- `DetailedError` is renamed to `ValidationErrors` and its inner class `ErrorDetail` to `ValidationError`.
- A new `Forbidden` class is added to handle 403 errors, with a nested `Detail` class for the error message and exception information.