### PR TITLE
Add Registration API and tests

### DIFF
--- a/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/MealieClient.kt
+++ b/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/MealieClient.kt
@@ -5,6 +5,8 @@ import com.saintpatrck.mealie.client.api.about.createAboutApi
 import com.saintpatrck.mealie.client.api.auth.AuthApi
 import com.saintpatrck.mealie.client.api.auth.createAuthApi
 import com.saintpatrck.mealie.client.api.model.MealieBearerTokens
+import com.saintpatrck.mealie.client.api.registration.RegistrationApi
+import com.saintpatrck.mealie.client.api.registration.createRegistrationApi
 import com.saintpatrck.mealie.client.infrastructure.ktorfit.mealieKtorfit
 import com.saintpatrck.mealie.client.model.MealieClientConfig
 import com.saintpatrck.mealie.client.provider.MealieTokenProvider
@@ -58,5 +60,12 @@ class MealieClient internal constructor(
      */
     val authApi: AuthApi by lazy {
         ktorfit.createAuthApi()
+    }
+
+    /**
+     * The API for registering a new user with the Mealie instance.
+     */
+    val registrationApi: RegistrationApi by lazy {
+        ktorfit.createRegistrationApi()
     }
 }

--- a/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/registration/RegistrationApi.kt
+++ b/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/registration/RegistrationApi.kt
@@ -1,0 +1,23 @@
+package com.saintpatrck.mealie.client.api.registration
+
+import com.saintpatrck.mealie.client.api.model.MealieResponse
+import com.saintpatrck.mealie.client.api.registration.model.RegisterUserRequestJson
+import com.saintpatrck.mealie.client.api.registration.model.RegisterUserResponseJson
+import de.jensklingenberg.ktorfit.http.Body
+import de.jensklingenberg.ktorfit.http.Headers
+import de.jensklingenberg.ktorfit.http.POST
+
+/**
+ * Represents the API for registering new users.
+ */
+interface RegistrationApi {
+
+    /**
+     * Registers a new user.
+     */
+    @Headers("Content-Type: application/json")
+    @POST("users/register")
+    suspend fun registerUser(
+        @Body user: RegisterUserRequestJson,
+    ): MealieResponse<RegisterUserResponseJson>
+}

--- a/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/registration/model/MealieAuthMethod.kt
+++ b/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/registration/model/MealieAuthMethod.kt
@@ -1,0 +1,13 @@
+package com.saintpatrck.mealie.client.api.registration.model
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Represents the authentication method used by the user.
+ */
+@Serializable
+enum class MealieAuthMethod {
+    MEALIE,
+    LDAP,
+    OIDC,
+}

--- a/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/registration/model/RegisterUserRequestJson.kt
+++ b/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/registration/model/RegisterUserRequestJson.kt
@@ -1,0 +1,48 @@
+package com.saintpatrck.mealie.client.api.registration.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Represents a request to register a user.
+ *
+ * @property group The name of the group to register the user in.
+ * @property household The name of the household to register the user in.
+ * @property groupToken The group token to register the user in.
+ * @property email The email of the user.
+ * @property username The username of the user.
+ * @property fullName The full name of the user.
+ * @property password The password of the user.
+ * @property passwordConfirm The password, again.
+ * @property advanced Whether the user can view advanced settings. Defaults to false.
+ * @property private Whether the users profile is private. Defaults to false.
+ * @property seedData Whether the user should be seeded with data. Defaults to false.
+ * @property locale The locale of the user. Defaults to "en-US".
+ */
+@Serializable
+data class RegisterUserRequestJson(
+    @SerialName("group")
+    val group: String?,
+    @SerialName("household")
+    val household: String?,
+    @SerialName("groupToken")
+    val groupToken: String?,
+    @SerialName("email")
+    val email: String,
+    @SerialName("username")
+    val username: String,
+    @SerialName("fullName")
+    val fullName: String,
+    @SerialName("password")
+    val password: String,
+    @SerialName("passwordConfirm")
+    val passwordConfirm: String,
+    @SerialName("advanced")
+    val advanced: Boolean = false,
+    @SerialName("private")
+    val private: Boolean = false,
+    @SerialName("seedData")
+    val seedData: Boolean = false,
+    @SerialName("locale")
+    val locale: String = "en-US",
+)

--- a/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/registration/model/RegisterUserResponseJson.kt
+++ b/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/registration/model/RegisterUserResponseJson.kt
@@ -1,0 +1,86 @@
+package com.saintpatrck.mealie.client.api.registration.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Represents a response from the login endpoint.
+ *
+ * @property id The ID of the user.
+ * @property email The email of the user.
+ * @property username The username of the user.
+ * @property fullName The full name of the user.
+ * @property authMethod The authentication method used by the user.
+ * @property admin Whether the user is an admin.
+ * @property group The name of the group the user belongs to.
+ * @property household The name of the household the user belongs to.
+ * @property advanced Whether the user has advanced settings enabled.
+ * @property canInvite Whether the user can invite other users.
+ * @property canManage Whether the user can manage other users.
+ * @property canManageHousehold Whether the user can manage the household.
+ * @property canOrganize Whether the user can organize events.
+ * @property groupId The ID of the group the user belongs to.
+ * @property groupSlug The slug of the group the user belongs to.
+ * @property householdId The ID of the household the user belongs to.
+ * @property householdSlug The slug of the household the user belongs to.
+ * @property tokens The tokens associated with the user.
+ * @property cacheKey The cache key associated with the user.
+ */
+@Serializable
+data class RegisterUserResponseJson(
+    @SerialName("id")
+    val id: String,
+    @SerialName("email")
+    val email: String,
+    @SerialName("username")
+    val username: String?,
+    @SerialName("fullName")
+    val fullName: String?,
+    @SerialName("authMethod")
+    val authMethod: MealieAuthMethod = MealieAuthMethod.MEALIE,
+    @SerialName("admin")
+    val admin: Boolean = false,
+    @SerialName("group")
+    val group: String,
+    @SerialName("household")
+    val household: String,
+    @SerialName("advanced")
+    val advanced: Boolean = false,
+    @SerialName("canInvite")
+    val canInvite: Boolean = false,
+    @SerialName("canManage")
+    val canManage: Boolean = false,
+    @SerialName("canManageHousehold")
+    val canManageHousehold: Boolean = false,
+    @SerialName("canOrganize")
+    val canOrganize: Boolean = false,
+    @SerialName("groupId")
+    val groupId: String,
+    @SerialName("groupSlug")
+    val groupSlug: String,
+    @SerialName("householdId")
+    val householdId: String,
+    @SerialName("householdSlug")
+    val householdSlug: String,
+    @SerialName("tokens")
+    val tokens: List<MealieToken>,
+    @SerialName("cacheKey")
+    val cacheKey: String,
+) {
+    /**
+     * Models an API token associated with the user.
+     *
+     * @property id The ID of the token.
+     * @property name The name of the token.
+     * @property createdAt The date and time when the token was created.
+     */
+    @Serializable
+    data class MealieToken(
+        @SerialName("id")
+        val id: String,
+        @SerialName("name")
+        val name: String,
+        @SerialName("createdAt")
+        val createdAt: String?,
+    )
+}

--- a/client/src/commonTest/kotlin/com/saintpatrck/mealie/client/api/registration/RegistrationApiTest.kt
+++ b/client/src/commonTest/kotlin/com/saintpatrck/mealie/client/api/registration/RegistrationApiTest.kt
@@ -1,0 +1,99 @@
+package com.saintpatrck.mealie.client.api.registration
+
+import com.saintpatrck.mealie.client.api.base.BaseApiTest
+import com.saintpatrck.mealie.client.api.model.getOrNull
+import com.saintpatrck.mealie.client.api.registration.model.MealieAuthMethod
+import com.saintpatrck.mealie.client.api.registration.model.RegisterUserRequestJson
+import com.saintpatrck.mealie.client.api.registration.model.RegisterUserResponseJson
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class RegistrationApiTest : BaseApiTest() {
+
+    @Test
+    fun `registerUser should deserialize correctly`() = runTest {
+        createTestMealieClient(responseJson = REGISTER_USER_RESPONSE_JSON)
+            .registrationApi
+            .registerUser(
+                user = RegisterUserRequestJson(
+                    email = "test@email.com",
+                    fullName = "Test",
+                    password = "password",
+                    passwordConfirm = "password",
+                    username = "username",
+                    group = null,
+                    household = null,
+                    groupToken = null,
+                    advanced = false,
+                    private = true,
+                    seedData = false,
+                    locale = "en-US",
+                )
+            )
+            .also { response ->
+                assertEquals(
+                    createMockRegisterUserResponseJson(),
+                    response.getOrNull(),
+                )
+            }
+    }
+}
+
+private const val REGISTER_USER_RESPONSE_JSON = """
+{
+  "username": "username",
+  "email": "test@email.com",
+  "fullName": "fullName",
+  "group": "group",
+  "household": "householdId",
+  "groupId": "groupId",
+  "advanced": false,
+  "canManageHousehold": false,
+  "id": "id",
+  "authMethod": "MEALIE",
+  "admin": false,
+  "canInvite": false,
+  "canManage": false,
+  "canOrganize": false,
+  "groupSlug": "groupSlug",
+  "householdId": "householdId",
+  "householdSlug": "householdSlug",
+  "tokens": [
+    {
+      "id": "id",
+      "name": "name",
+      "createdAt": "createdAt"
+    }
+  ],
+  "cacheKey": "cacheKey"
+}
+"""
+
+fun createMockRegisterUserResponseJson() = RegisterUserResponseJson(
+    username = "username",
+    email = "test@email.com",
+    fullName = "fullName",
+    group = "group",
+    household = "householdId",
+    groupId = "groupId",
+    advanced = false,
+    canManageHousehold = false,
+    id = "id",
+    authMethod = MealieAuthMethod.MEALIE,
+    admin = false,
+    canInvite = false,
+    canManage = false,
+    canOrganize = false,
+    groupSlug = "groupSlug",
+    householdId = "householdId",
+    householdSlug = "householdSlug",
+    tokens = listOf(
+        RegisterUserResponseJson.MealieToken(
+            id = "id",
+            name = "name",
+            createdAt = "createdAt",
+        )
+    ),
+    cacheKey = "cacheKey",
+)


### PR DESCRIPTION
This commit introduces the `RegistrationApi` for handling user registration. It includes:
- `RegistrationApi` interface with a `registerUser` method.
- Data models for request (`RegisterUserRequestJson`) and response (`RegisterUserResponseJson`).
- `MealieAuthMethod` enum to specify user authentication methods.
- Integration of `RegistrationApi` into `MealieClient`.
- Unit tests (`RegistrationApiTest`) for the `registerUser` endpoint, ensuring correct deserialization of the response.