### PR TITLE
Add `ratings` endpoint and test for deserialization

### DIFF
--- a/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/user/UserApi.kt
+++ b/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/user/UserApi.kt
@@ -1,6 +1,7 @@
 package com.saintpatrck.mealie.client.api.user
 
 import com.saintpatrck.mealie.client.api.model.MealieResponse
+import com.saintpatrck.mealie.client.api.user.model.SelfRatingsResponseJson
 import com.saintpatrck.mealie.client.api.user.model.SelfResponseJson
 import de.jensklingenberg.ktorfit.http.GET
 
@@ -15,4 +16,9 @@ interface UserApi {
     @GET("users/self")
     suspend fun self(): MealieResponse<SelfResponseJson>
 
+    /**
+     * Retrieves the current user's rated recipes.
+     */
+    @GET("users/self/ratings")
+    suspend fun ratings(): MealieResponse<SelfRatingsResponseJson>
 }

--- a/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/user/model/SelfRatingsResponseJson.kt
+++ b/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/user/model/SelfRatingsResponseJson.kt
@@ -1,0 +1,32 @@
+package com.saintpatrck.mealie.client.api.user.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Represents the response from the /users/self/ratings endpoint.
+ *
+ * @property ratings The list of ratings.
+ */
+@Serializable
+data class SelfRatingsResponseJson(
+    @SerialName("ratings")
+    val ratings: List<Rating>,
+) {
+    /**
+     * Represents a rating for a recipe.
+     *
+     * @property recipeId The ID of the recipe.
+     * @property rating The rating given to the recipe.
+     * @property isFavorite Whether the recipe is a favorite.
+     */
+    @Serializable
+    data class Rating(
+        @SerialName("recipeId")
+        val recipeId: String,
+        @SerialName("rating")
+        val rating: Double,
+        @SerialName("isFavorite")
+        val isFavorite: Boolean,
+    )
+}

--- a/client/src/commonTest/kotlin/com/saintpatrck/mealie/client/api/user/UserApiTest.kt
+++ b/client/src/commonTest/kotlin/com/saintpatrck/mealie/client/api/user/UserApiTest.kt
@@ -4,6 +4,7 @@ import com.saintpatrck.mealie.client.api.base.BaseApiTest
 import com.saintpatrck.mealie.client.api.model.MealieToken
 import com.saintpatrck.mealie.client.api.model.getOrNull
 import com.saintpatrck.mealie.client.api.registration.model.MealieAuthMethod
+import com.saintpatrck.mealie.client.api.user.model.SelfRatingsResponseJson
 import com.saintpatrck.mealie.client.api.user.model.SelfResponseJson
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
@@ -19,6 +20,19 @@ class UserApiTest : BaseApiTest() {
             .also { response ->
                 assertEquals(
                     createMockSelfResponseJson(),
+                    response.getOrNull(),
+                )
+            }
+    }
+
+    @Test
+    fun `ratings should deserialize correctly`() = runTest {
+        createTestMealieClient(responseJson = SELF_RATINGS_RESPONSE_JSON)
+            .userApi
+            .ratings()
+            .also { response ->
+                assertEquals(
+                    createMockSelfRatingsResponseJson(),
                     response.getOrNull(),
                 )
             }
@@ -54,6 +68,17 @@ private const val SELF_RESPONSE_JSON = """
   "cacheKey": "cacheKey"
 }
 """
+private const val SELF_RATINGS_RESPONSE_JSON = """
+{
+  "ratings": [
+    {
+      "recipeId": "recipeId",
+      "rating": 1.0,
+      "isFavorite": false
+    }
+  ]
+}
+"""
 
 private fun createMockSelfResponseJson() = SelfResponseJson(
     id = "id",
@@ -81,4 +106,14 @@ private fun createMockSelfResponseJson() = SelfResponseJson(
         )
     ),
     cacheKey = "cacheKey",
+)
+
+private fun createMockSelfRatingsResponseJson() = SelfRatingsResponseJson(
+    ratings = listOf(
+        SelfRatingsResponseJson.Rating(
+            recipeId = "recipeId",
+            rating = 1.0,
+            isFavorite = false,
+        )
+    ),
 )


### PR DESCRIPTION
This commit introduces the `ratings` endpoint to the `UserApi`, which retrieves the current user's rated recipes.

A new data class `SelfRatingsResponseJson` has been added to model the response from this endpoint.

Additionally, a test case `ratings should deserialize correctly` has been added to `UserApiTest.kt` to ensure the response from the new endpoint is deserialized correctly.