### PR TITLE
Update ErrorResponseJson model with optional fields

### DIFF
--- a/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/model/ErrorResponseJson.kt
+++ b/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/model/ErrorResponseJson.kt
@@ -38,6 +38,8 @@ sealed class ErrorResponseJson {
          * @property location The location of the error.
          * @property message The error message.
          * @property type The type of the error.
+         * @property input The input that caused the error.
+         * @property context The context of the error.
          */
         @Serializable
         data class ValidationError(
@@ -47,6 +49,10 @@ sealed class ErrorResponseJson {
             val message: String,
             @SerialName("type")
             val type: String?,
+            @SerialName("input")
+            val input: String?,
+            @SerialName("ctx")
+            val context: Map<String, String?>?,
         )
     }
 

--- a/client/src/commonTest/kotlin/com/saintpatrck/mealie/client/serializer/ErrorResponseJsonSerializerTest.kt
+++ b/client/src/commonTest/kotlin/com/saintpatrck/mealie/client/serializer/ErrorResponseJsonSerializerTest.kt
@@ -63,13 +63,6 @@ class ErrorResponseJsonSerializerTest : BaseApiTest() {
     }
 }
 
-private val UNAUTHORIZED_ERROR_RESPONSE = """
-{
-    "detail": "string"
-}
-"""
-    .trimIndent()
-
 private val VALIDATION_ERROR_RESPONSE = """
 {
   "detail": [
@@ -78,19 +71,35 @@ private val VALIDATION_ERROR_RESPONSE = """
         "string"
       ],
       "msg": "string",
-      "type": "string"
+      "type": "string",
+      "input": null,
+      "ctx": null
     },
     {
       "loc": [
         "string"
       ],
       "msg": "string",
-      "type": "string"
+      "type": "string",
+      "input": null,
+      "ctx": {
+        "key1": "string",
+        "key2": 1,
+        "key3": null
+      }
     }
   ]
 }
 """
     .trimIndent()
+
+private val UNAUTHORIZED_ERROR_RESPONSE = """
+{
+    "detail": "string"
+}
+"""
+    .trimIndent()
+
 
 private val FORBIDDEN_ERROR_RESPONSE = """
 {
@@ -109,11 +118,19 @@ private fun createMockValidationErrorResponseJson() = ErrorResponseJson.Validati
             location = listOf("string"),
             message = "string",
             type = "string",
+            input = null,
+            context = null,
         ),
         ErrorResponseJson.ValidationErrors.ValidationError(
             location = listOf("string"),
             message = "string",
             type = "string",
+            input = null,
+            context = mapOf(
+                "key1" to "string",
+                "key2" to "1",
+                "key3" to null,
+            ),
         ),
     )
 )


### PR DESCRIPTION
This commit updates the `ErrorResponseJson.ValidationErrors.ValidationError` data class to include optional `input` and `context` fields.

The corresponding test `ErrorResponseJsonSerializerTest` has also been updated to reflect these changes.