### PR TITLE
Refactor rating model

### DIFF
--- a/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/model/Rating.kt
+++ b/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/model/Rating.kt
@@ -1,0 +1,21 @@
+package com.saintpatrck.mealie.client.api.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Represents a rating for a recipe.
+ *
+ * @property recipeId The ID of the recipe.
+ * @property rating The rating given to the recipe.
+ * @property isFavorite Whether the recipe is a favorite.
+ */
+@Serializable
+data class Rating(
+    @SerialName("recipeId")
+    val recipeId: String,
+    @SerialName("rating")
+    val rating: Double,
+    @SerialName("isFavorite")
+    val isFavorite: Boolean,
+)

--- a/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/user/model/SelfRatingsResponseJson.kt
+++ b/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/user/model/SelfRatingsResponseJson.kt
@@ -1,5 +1,6 @@
 package com.saintpatrck.mealie.client.api.user.model
 
+import com.saintpatrck.mealie.client.api.model.Rating
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -12,21 +13,4 @@ import kotlinx.serialization.Serializable
 data class SelfRatingsResponseJson(
     @SerialName("ratings")
     val ratings: List<Rating>,
-) {
-    /**
-     * Represents a rating for a recipe.
-     *
-     * @property recipeId The ID of the recipe.
-     * @property rating The rating given to the recipe.
-     * @property isFavorite Whether the recipe is a favorite.
-     */
-    @Serializable
-    data class Rating(
-        @SerialName("recipeId")
-        val recipeId: String,
-        @SerialName("rating")
-        val rating: Double,
-        @SerialName("isFavorite")
-        val isFavorite: Boolean,
-    )
-}
+)


### PR DESCRIPTION
This commit moves the `Rating` data class from `SelfRatingsResponseJson.kt` to its own file `Rating.kt` under `com.saintpatrck.mealie.client.api.model`.

This change improves code organization by separating the model from the response DTO.