### PR TITLE
Add `ratingForRecipe` endpoint to UserApi

### DIFF
--- a/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/user/UserApi.kt
+++ b/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/user/UserApi.kt
@@ -1,9 +1,12 @@
 package com.saintpatrck.mealie.client.api.user
 
+import com.saintpatrck.mealie.client.api.model.ErrorResponseJson
 import com.saintpatrck.mealie.client.api.model.MealieResponse
+import com.saintpatrck.mealie.client.api.model.Rating
 import com.saintpatrck.mealie.client.api.user.model.SelfRatingsResponseJson
 import com.saintpatrck.mealie.client.api.user.model.SelfResponseJson
 import de.jensklingenberg.ktorfit.http.GET
+import de.jensklingenberg.ktorfit.http.Path
 
 /**
  * Represents the API for managing user information.
@@ -11,7 +14,7 @@ import de.jensklingenberg.ktorfit.http.GET
 interface UserApi {
 
     /**
-     * Gets the current user's information.
+     * Retrieves the current user's information.
      */
     @GET("users/self")
     suspend fun self(): MealieResponse<SelfResponseJson>
@@ -21,4 +24,17 @@ interface UserApi {
      */
     @GET("users/self/ratings")
     suspend fun ratings(): MealieResponse<SelfRatingsResponseJson>
+
+    /**
+     * Retrieves the current user's rating for a specific recipe.
+     *
+     * If the user has not rated the recipe, an [ErrorResponseJson] will be returned.
+     *
+     * @param recipeId The ID of the recipe.
+     */
+    @GET("users/rating/{recipeId}")
+    suspend fun ratingForRecipe(
+        @Path("recipeId")
+        recipeId: String,
+    ): MealieResponse<Rating>
 }

--- a/client/src/commonTest/kotlin/com/saintpatrck/mealie/client/api/user/UserApiTest.kt
+++ b/client/src/commonTest/kotlin/com/saintpatrck/mealie/client/api/user/UserApiTest.kt
@@ -2,6 +2,7 @@ package com.saintpatrck.mealie.client.api.user
 
 import com.saintpatrck.mealie.client.api.base.BaseApiTest
 import com.saintpatrck.mealie.client.api.model.MealieToken
+import com.saintpatrck.mealie.client.api.model.Rating
 import com.saintpatrck.mealie.client.api.model.getOrNull
 import com.saintpatrck.mealie.client.api.registration.model.MealieAuthMethod
 import com.saintpatrck.mealie.client.api.user.model.SelfRatingsResponseJson
@@ -37,9 +38,22 @@ class UserApiTest : BaseApiTest() {
                 )
             }
     }
+
+    @Test
+    fun `ratingForRecipe should deserialize correctly`() = runTest {
+        createTestMealieClient(responseJson = SELF_RATING_FOR_RECIPE_RESPONSE_JSON)
+            .userApi
+            .ratingForRecipe("recipeId")
+            .also { response ->
+                assertEquals(
+                    createMockRatingForRecipeResponseJson(),
+                    response.getOrNull(),
+                )
+            }
+    }
 }
 
-private const val SELF_RESPONSE_JSON = """
+private val SELF_RESPONSE_JSON = """
 {
   "username": "username",
   "email": "test@email.com",
@@ -68,7 +82,7 @@ private const val SELF_RESPONSE_JSON = """
   "cacheKey": "cacheKey"
 }
 """
-private const val SELF_RATINGS_RESPONSE_JSON = """
+private val SELF_RATINGS_RESPONSE_JSON = """
 {
   "ratings": [
     {
@@ -79,6 +93,15 @@ private const val SELF_RATINGS_RESPONSE_JSON = """
   ]
 }
 """
+    .trimIndent()
+private val SELF_RATING_FOR_RECIPE_RESPONSE_JSON = """
+{
+  "recipeId": "recipeId",
+  "rating": 1.0,
+  "isFavorite": false
+}
+"""
+    .trimIndent()
 
 private fun createMockSelfResponseJson() = SelfResponseJson(
     id = "id",
@@ -110,10 +133,16 @@ private fun createMockSelfResponseJson() = SelfResponseJson(
 
 private fun createMockSelfRatingsResponseJson() = SelfRatingsResponseJson(
     ratings = listOf(
-        SelfRatingsResponseJson.Rating(
+        Rating(
             recipeId = "recipeId",
             rating = 1.0,
             isFavorite = false,
         )
     ),
+)
+
+private fun createMockRatingForRecipeResponseJson() = Rating(
+    recipeId = "recipeId",
+    rating = 1.0,
+    isFavorite = false,
 )


### PR DESCRIPTION
This commit adds a new endpoint `ratingForRecipe` to the `UserApi` interface. This endpoint allows retrieving the current user's rating for a specific recipe identified by its `recipeId`.

The commit also includes:
- Corresponding tests for the new endpoint in `UserApiTest.kt`.
- Updates to the KDoc for the existing `self` endpoint.
- Use of `Rating` model for the response of the new endpoint and for the `ratings` in `SelfRatingsResponseJson`.