### PR TITLE
Fix recipe rating API path

### DIFF
--- a/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/user/UserApi.kt
+++ b/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/user/UserApi.kt
@@ -32,7 +32,7 @@ interface UserApi {
      *
      * @param recipeId The ID of the recipe.
      */
-    @GET("users/rating/{recipeId}")
+    @GET("users/self/ratings/{recipeId}")
     suspend fun ratingForRecipe(
         @Path("recipeId")
         recipeId: String,


### PR DESCRIPTION
The API path for retrieving a recipe rating has been corrected from `users/rating/{recipeId}` to `users/self/ratings/{recipeId}`.