### PR TITLE
Add UserApi favorites endpoint

### DIFF
--- a/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/user/UserApi.kt
+++ b/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/user/UserApi.kt
@@ -3,6 +3,7 @@ package com.saintpatrck.mealie.client.api.user
 import com.saintpatrck.mealie.client.api.model.ErrorResponseJson
 import com.saintpatrck.mealie.client.api.model.MealieResponse
 import com.saintpatrck.mealie.client.api.model.Rating
+import com.saintpatrck.mealie.client.api.user.model.SelfFavoritesResponseJson
 import com.saintpatrck.mealie.client.api.user.model.SelfRatingsResponseJson
 import com.saintpatrck.mealie.client.api.user.model.SelfResponseJson
 import de.jensklingenberg.ktorfit.http.GET
@@ -37,4 +38,10 @@ interface UserApi {
         @Path("recipeId")
         recipeId: String,
     ): MealieResponse<Rating>
+
+    /**
+     * Retrieves the current user's favorite recipes.
+     */
+    @GET("users/self/favorites")
+    suspend fun favorites(): MealieResponse<SelfFavoritesResponseJson>
 }

--- a/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/user/model/SelfFavoritesResponseJson.kt
+++ b/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/user/model/SelfFavoritesResponseJson.kt
@@ -1,0 +1,16 @@
+package com.saintpatrck.mealie.client.api.user.model
+
+import com.saintpatrck.mealie.client.api.model.Rating
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Represents the response from the /users/self/favorites endpoint.
+ *
+ * @property ratings The list of users favorite recipes.
+ */
+@Serializable
+data class SelfFavoritesResponseJson(
+    @SerialName("ratings")
+    val ratings: List<Rating>,
+)

--- a/client/src/commonTest/kotlin/com/saintpatrck/mealie/client/api/user/UserApiTest.kt
+++ b/client/src/commonTest/kotlin/com/saintpatrck/mealie/client/api/user/UserApiTest.kt
@@ -5,6 +5,7 @@ import com.saintpatrck.mealie.client.api.model.MealieToken
 import com.saintpatrck.mealie.client.api.model.Rating
 import com.saintpatrck.mealie.client.api.model.getOrNull
 import com.saintpatrck.mealie.client.api.registration.model.MealieAuthMethod
+import com.saintpatrck.mealie.client.api.user.model.SelfFavoritesResponseJson
 import com.saintpatrck.mealie.client.api.user.model.SelfRatingsResponseJson
 import com.saintpatrck.mealie.client.api.user.model.SelfResponseJson
 import kotlinx.coroutines.test.runTest
@@ -51,6 +52,19 @@ class UserApiTest : BaseApiTest() {
                 )
             }
     }
+
+    @Test
+    fun `favorites should deserialize correctly`() = runTest {
+        createTestMealieClient(responseJson = SELF_FAVORITES_RESPONSE_JSON)
+            .userApi
+            .favorites()
+            .also { response ->
+                assertEquals(
+                    createMockSelfFavoritesResponseJson(),
+                    response.getOrNull(),
+                )
+            }
+    }
 }
 
 private val SELF_RESPONSE_JSON = """
@@ -82,6 +96,7 @@ private val SELF_RESPONSE_JSON = """
   "cacheKey": "cacheKey"
 }
 """
+    .trimIndent()
 private val SELF_RATINGS_RESPONSE_JSON = """
 {
   "ratings": [
@@ -99,6 +114,18 @@ private val SELF_RATING_FOR_RECIPE_RESPONSE_JSON = """
   "recipeId": "recipeId",
   "rating": 1.0,
   "isFavorite": false
+}
+"""
+    .trimIndent()
+private val SELF_FAVORITES_RESPONSE_JSON = """
+{
+  "ratings": [
+    {
+      "recipeId": "recipeId",
+      "rating": 1.0,
+      "isFavorite": false
+    }
+  ]
 }
 """
     .trimIndent()
@@ -146,3 +173,14 @@ private fun createMockRatingForRecipeResponseJson() = Rating(
     rating = 1.0,
     isFavorite = false,
 )
+
+private fun createMockSelfFavoritesResponseJson() = SelfFavoritesResponseJson(
+    ratings = listOf(
+        Rating(
+            recipeId = "recipeId",
+            rating = 1.0,
+            isFavorite = false,
+        )
+    ),
+)
+


### PR DESCRIPTION
This commit introduces a new endpoint to the `UserApi` for retrieving the current user's favorite recipes.

It includes:
- The `favorites()` suspend function in `UserApi.kt` to call the `/users/self/favorites` endpoint.
- The `SelfFavoritesResponseJson` data class to model the response from this endpoint.
- A corresponding test in `UserApiTest.kt` to verify the correct deserialization of the favorites response.