### PR TITLE
Add `updatePassword` to `UserApi`

### DIFF
--- a/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/user/UserApi.kt
+++ b/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/user/UserApi.kt
@@ -6,7 +6,11 @@ import com.saintpatrck.mealie.client.api.model.Rating
 import com.saintpatrck.mealie.client.api.user.model.SelfFavoritesResponseJson
 import com.saintpatrck.mealie.client.api.user.model.SelfRatingsResponseJson
 import com.saintpatrck.mealie.client.api.user.model.SelfResponseJson
+import com.saintpatrck.mealie.client.api.user.model.UpdatePasswordRequestJson
+import de.jensklingenberg.ktorfit.http.Body
 import de.jensklingenberg.ktorfit.http.GET
+import de.jensklingenberg.ktorfit.http.Headers
+import de.jensklingenberg.ktorfit.http.PUT
 import de.jensklingenberg.ktorfit.http.Path
 
 /**
@@ -44,4 +48,14 @@ interface UserApi {
      */
     @GET("users/self/favorites")
     suspend fun favorites(): MealieResponse<SelfFavoritesResponseJson>
+
+    /**
+     * Changes the current user's password.
+     */
+    @Headers("Content-Type: application/json")
+    @PUT("users/self/password")
+    suspend fun updatePassword(
+        @Body
+        updatePasswordRequestJson: UpdatePasswordRequestJson,
+    ): MealieResponse<Unit>
 }

--- a/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/user/model/UpdatePasswordRequestJson.kt
+++ b/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/user/model/UpdatePasswordRequestJson.kt
@@ -1,0 +1,18 @@
+package com.saintpatrck.mealie.client.api.user.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Represents a request to update the password of a user.
+ *
+ * @property currentPassword The current password of the user.
+ * @property newPassword The new password for the user.
+ */
+@Serializable
+data class UpdatePasswordRequestJson(
+    @SerialName("currentPassword")
+    val currentPassword: String,
+    @SerialName("newPassword")
+    val newPassword: String,
+)

--- a/client/src/commonTest/kotlin/com/saintpatrck/mealie/client/api/user/UserApiTest.kt
+++ b/client/src/commonTest/kotlin/com/saintpatrck/mealie/client/api/user/UserApiTest.kt
@@ -8,6 +8,7 @@ import com.saintpatrck.mealie.client.api.registration.model.MealieAuthMethod
 import com.saintpatrck.mealie.client.api.user.model.SelfFavoritesResponseJson
 import com.saintpatrck.mealie.client.api.user.model.SelfRatingsResponseJson
 import com.saintpatrck.mealie.client.api.user.model.SelfResponseJson
+import com.saintpatrck.mealie.client.api.user.model.UpdatePasswordRequestJson
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -61,6 +62,24 @@ class UserApiTest : BaseApiTest() {
             .also { response ->
                 assertEquals(
                     createMockSelfFavoritesResponseJson(),
+                    response.getOrNull(),
+                )
+            }
+    }
+
+    @Test
+    fun `updatePassword should deserialize correctly`() = runTest {
+        createTestMealieClient(responseJson = "")
+            .userApi
+            .updatePassword(
+                updatePasswordRequestJson = UpdatePasswordRequestJson(
+                    currentPassword = "currentPassword",
+                    newPassword = "newPassword",
+                )
+            )
+            .also { response ->
+                assertEquals(
+                    Unit,
                     response.getOrNull(),
                 )
             }


### PR DESCRIPTION
This commit introduces the `updatePassword` function to the `UserApi` interface. This function allows users to change their password.

Additionally, the `UpdatePasswordRequestJson` data class has been added to represent the request body for updating the password.