### PR TITLE
Add merge_group trigger to build-and-test workflow

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,6 +1,7 @@
 name: Build and Test
 
 on:
+  merge_group:
   push:
     branches: [ "main" ]
   pull_request_target:


### PR DESCRIPTION
This commit adds the `merge_group` event to the triggers for the `build-and-test.yml` GitHub Actions workflow. This will ensure the workflow runs when changes are merged into the main branch via a merge queue.