### PR TITLE
Add UpdateUserRequestJson and test

### DIFF
--- a/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/user/UserApi.kt
+++ b/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/user/UserApi.kt
@@ -7,6 +7,7 @@ import com.saintpatrck.mealie.client.api.user.model.SelfFavoritesResponseJson
 import com.saintpatrck.mealie.client.api.user.model.SelfRatingsResponseJson
 import com.saintpatrck.mealie.client.api.user.model.SelfResponseJson
 import com.saintpatrck.mealie.client.api.user.model.UpdatePasswordRequestJson
+import com.saintpatrck.mealie.client.api.user.model.UpdateUserRequestJson
 import de.jensklingenberg.ktorfit.http.Body
 import de.jensklingenberg.ktorfit.http.GET
 import de.jensklingenberg.ktorfit.http.Headers
@@ -57,5 +58,14 @@ interface UserApi {
     suspend fun updatePassword(
         @Body
         updatePasswordRequestJson: UpdatePasswordRequestJson,
+    ): MealieResponse<Unit>
+
+    @Headers("Content-Type: application/json")
+    @PUT("users/{userId}")
+    suspend fun updateUser(
+        @Path("userId")
+        userId: String,
+        @Body
+        updateUserRequestJson: UpdateUserRequestJson,
     ): MealieResponse<Unit>
 }

--- a/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/user/model/UpdateUserRequestJson.kt
+++ b/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/user/model/UpdateUserRequestJson.kt
@@ -1,0 +1,38 @@
+package com.saintpatrck.mealie.client.api.user.model
+
+import com.saintpatrck.mealie.client.api.registration.model.MealieAuthMethod
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Represents a request to update a user's information.
+ */
+@Serializable
+data class UpdateUserRequestJson(
+    @SerialName("id")
+    val id: String,
+    @SerialName("username")
+    val username: String?,
+    @SerialName("fullName")
+    val fullName: String?,
+    @SerialName("email")
+    val email: String,
+    @SerialName("authMethod")
+    val authMethod: MealieAuthMethod,
+    @SerialName("admin")
+    val admin: Boolean,
+    @SerialName("group")
+    val group: String?,
+    @SerialName("household")
+    val household: String?,
+    @SerialName("advanced")
+    val advanced: Boolean,
+    @SerialName("canInvite")
+    val canInvite: Boolean,
+    @SerialName("canManage")
+    val canManage: Boolean,
+    @SerialName("canManageHousehold")
+    val canManageHousehold: Boolean,
+    @SerialName("canOrganize")
+    val canOrganize: Boolean,
+)

--- a/client/src/commonTest/kotlin/com/saintpatrck/mealie/client/api/user/UserApiTest.kt
+++ b/client/src/commonTest/kotlin/com/saintpatrck/mealie/client/api/user/UserApiTest.kt
@@ -9,6 +9,7 @@ import com.saintpatrck.mealie.client.api.user.model.SelfFavoritesResponseJson
 import com.saintpatrck.mealie.client.api.user.model.SelfRatingsResponseJson
 import com.saintpatrck.mealie.client.api.user.model.SelfResponseJson
 import com.saintpatrck.mealie.client.api.user.model.UpdatePasswordRequestJson
+import com.saintpatrck.mealie.client.api.user.model.UpdateUserRequestJson
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -75,6 +76,36 @@ class UserApiTest : BaseApiTest() {
                 updatePasswordRequestJson = UpdatePasswordRequestJson(
                     currentPassword = "currentPassword",
                     newPassword = "newPassword",
+                )
+            )
+            .also { response ->
+                assertEquals(
+                    Unit,
+                    response.getOrNull(),
+                )
+            }
+    }
+
+    @Test
+    fun `updateUser should deserialize correctly`() = runTest {
+        createTestMealieClient(responseJson = "")
+            .userApi
+            .updateUser(
+                userId = "userId",
+                updateUserRequestJson = UpdateUserRequestJson(
+                    id = "id",
+                    username = "username",
+                    fullName = "fullName",
+                    email = "email",
+                    authMethod = MealieAuthMethod.MEALIE,
+                    admin = false,
+                    group = "group",
+                    household = "household",
+                    advanced = false,
+                    canInvite = false,
+                    canManage = false,
+                    canManageHousehold = false,
+                    canOrganize = false,
                 )
             )
             .also { response ->


### PR DESCRIPTION
This commit introduces `UpdateUserRequestJson` for updating user information. It includes a new data class and an extension to `UserApi` to handle the update request. A corresponding test case in `UserApiTest` ensures correct deserialization.