### PR TITLE
Add Admin API for user management

### DIFF
--- a/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/MealieClient.kt
+++ b/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/MealieClient.kt
@@ -2,6 +2,8 @@ package com.saintpatrck.mealie.client
 
 import com.saintpatrck.mealie.client.api.about.AboutApi
 import com.saintpatrck.mealie.client.api.about.createAboutApi
+import com.saintpatrck.mealie.client.api.admin.AdminApi
+import com.saintpatrck.mealie.client.api.admin.createAdminApi
 import com.saintpatrck.mealie.client.api.auth.AuthApi
 import com.saintpatrck.mealie.client.api.auth.createAuthApi
 import com.saintpatrck.mealie.client.api.model.MealieBearerTokens
@@ -55,6 +57,13 @@ class MealieClient internal constructor(
      */
     val aboutApi: AboutApi by lazy {
         ktorfit.createAboutApi()
+    }
+
+    /**
+     * The API for administering users.
+     */
+    val adminApi: AdminApi by lazy {
+        ktorfit.createAdminApi()
     }
 
     /**

--- a/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/admin/AdminApi.kt
+++ b/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/admin/AdminApi.kt
@@ -1,0 +1,23 @@
+package com.saintpatrck.mealie.client.api.admin
+
+import com.saintpatrck.mealie.client.api.admin.model.UserResponseJson
+import com.saintpatrck.mealie.client.api.model.MealieResponse
+import de.jensklingenberg.ktorfit.http.GET
+import de.jensklingenberg.ktorfit.http.Path
+
+/**
+ * Represents the API for administering users.
+ */
+interface AdminApi {
+
+    /**
+     * Retrieves a user with the given [userId].
+     *
+     * @param userId The ID of the user to retrieve.
+     */
+    @GET("users/{userId}")
+    suspend fun getUser(
+        @Path("userId")
+        userId: String,
+    ): MealieResponse<UserResponseJson>
+}

--- a/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/admin/model/UserResponseJson.kt
+++ b/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/admin/model/UserResponseJson.kt
@@ -1,0 +1,51 @@
+package com.saintpatrck.mealie.client.api.admin.model
+
+import com.saintpatrck.mealie.client.api.model.MealieToken
+import com.saintpatrck.mealie.client.api.registration.model.MealieAuthMethod
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Represents a user response from the get user API.
+ */
+@Serializable
+data class UserResponseJson(
+    @SerialName("id")
+    val id: String,
+    @SerialName("username")
+    val username: String?,
+    @SerialName("fullName")
+    val fullName: String?,
+    @SerialName("email")
+    val email: String,
+    @SerialName("authMethod")
+    val authMethod: MealieAuthMethod,
+    @SerialName("admin")
+    val admin: Boolean,
+    @SerialName("group")
+    val group: String,
+    @SerialName("household")
+    val household: String,
+    @SerialName("advanced")
+    val advanced: Boolean,
+    @SerialName("canInvite")
+    val canInvite: Boolean,
+    @SerialName("canManage")
+    val canManage: Boolean,
+    @SerialName("canManageHousehold")
+    val canManageHousehold: Boolean,
+    @SerialName("canOrganize")
+    val canOrganize: Boolean,
+    @SerialName("groupId")
+    val groupId: String,
+    @SerialName("groupSlug")
+    val groupSlug: String,
+    @SerialName("householdId")
+    val householdId: String,
+    @SerialName("householdSlug")
+    val householdSlug: String,
+    @SerialName("tokens")
+    val tokens: List<MealieToken>,
+    @SerialName("cacheKey")
+    val cacheKey: String,
+)

--- a/client/src/commonTest/kotlin/com/saintpatrck/mealie/client/api/admin/AdminApiTest.kt
+++ b/client/src/commonTest/kotlin/com/saintpatrck/mealie/client/api/admin/AdminApiTest.kt
@@ -1,0 +1,86 @@
+package com.saintpatrck.mealie.client.api.admin
+
+import com.saintpatrck.mealie.client.api.admin.model.UserResponseJson
+import com.saintpatrck.mealie.client.api.base.BaseApiTest
+import com.saintpatrck.mealie.client.api.model.MealieToken
+import com.saintpatrck.mealie.client.api.model.getOrNull
+import com.saintpatrck.mealie.client.api.registration.model.MealieAuthMethod
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class AdminApiTest : BaseApiTest() {
+
+    @Test
+    fun `getUser should deserialize correctly`() = runTest {
+        createTestMealieClient(responseJson = GET_USER_RESPONSE_JSON)
+            .adminApi
+            .getUser("userId")
+            .also { response ->
+                assertEquals(
+                    createMockUserResponseJson(),
+                    response.getOrNull(),
+                )
+            }
+    }
+}
+
+private val GET_USER_RESPONSE_JSON = """
+{
+  "id": "id",
+  "username": "username",
+  "email": "email",
+  "fullName": "fullName",
+  "group": "group",
+  "household": "household",
+  "groupId": "groupId",
+  "advanced": false,
+  "canManageHousehold": false,
+  "authMethod": "MEALIE",
+  "admin": false,
+  "canInvite": false,
+  "canManage": false,
+  "canOrganize": false,
+  "groupSlug": "groupSlug",
+  "householdId": "householdId",
+  "householdSlug": "householdSlug",
+  "tokens": [
+    {
+      "id": "id",
+      "name": "name",
+      "createdAt": "createdAt"
+    }
+  ],
+  "cacheKey": "cacheKey"
+}    
+"""
+    .trimIndent()
+
+
+private fun createMockUserResponseJson() = UserResponseJson(
+    id = "id",
+    username = "username",
+    fullName = "fullName",
+    email = "email",
+    authMethod = MealieAuthMethod.MEALIE,
+    admin = false,
+    group = "group",
+    household = "household",
+    advanced = false,
+    canInvite = false,
+    canManage = false,
+    canManageHousehold = false,
+    canOrganize = false,
+    groupId = "groupId",
+    groupSlug = "groupSlug",
+    householdId = "householdId",
+    householdSlug = "householdSlug",
+    tokens = listOf(
+        MealieToken(
+            id = "id",
+            name = "name",
+            createdAt = "createdAt",
+        )
+    ),
+    cacheKey = "cacheKey",
+)


### PR DESCRIPTION
This commit introduces the `AdminApi` for managing users. It includes:
- `AdminApi` interface with a `getUser` function to retrieve user details.
- `UserResponseJson` data class to model the user response.
- Unit tests for the `getUser` functionality, ensuring correct deserialization.