### PR TITLE
Add `AdminApi.deleteUser` function

### DIFF
--- a/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/admin/AdminApi.kt
+++ b/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/admin/AdminApi.kt
@@ -2,6 +2,7 @@ package com.saintpatrck.mealie.client.api.admin
 
 import com.saintpatrck.mealie.client.api.admin.model.UserResponseJson
 import com.saintpatrck.mealie.client.api.model.MealieResponse
+import de.jensklingenberg.ktorfit.http.DELETE
 import de.jensklingenberg.ktorfit.http.GET
 import de.jensklingenberg.ktorfit.http.Path
 
@@ -20,4 +21,13 @@ interface AdminApi {
         @Path("userId")
         userId: String,
     ): MealieResponse<UserResponseJson>
+
+    /**
+     * Deletes the user with the given [userId].
+     */
+    @DELETE("users/{userId}")
+    suspend fun deleteUser(
+        @Path("userId")
+        userId: String,
+    ): MealieResponse<Unit>
 }

--- a/client/src/commonTest/kotlin/com/saintpatrck/mealie/client/api/admin/AdminApiTest.kt
+++ b/client/src/commonTest/kotlin/com/saintpatrck/mealie/client/api/admin/AdminApiTest.kt
@@ -23,6 +23,19 @@ class AdminApiTest : BaseApiTest() {
                 )
             }
     }
+
+    @Test
+    fun `deleteUser should deserialize correctly`() = runTest {
+        createTestMealieClient(responseJson = "")
+            .adminApi
+            .deleteUser("userId")
+            .also { response ->
+                assertEquals(
+                    Unit,
+                    response.getOrNull(),
+                )
+            }
+    }
 }
 
 private val GET_USER_RESPONSE_JSON = """


### PR DESCRIPTION
This commit introduces the `deleteUser` function to the `AdminApi`. This function allows for the deletion of a user by their ID.

Additionally, a corresponding test case `deleteUser should deserialize correctly` has been added to ensure the correct deserialization of the response.