### PR TITLE
Add PagedResponseJson and related models

### DIFF
--- a/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/model/OrderByNullPosition.kt
+++ b/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/model/OrderByNullPosition.kt
@@ -4,7 +4,7 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 /**
- * Represents the order direction for sorting.
+ * Represents the position of null values when sorting results.
  */
 @Serializable
 enum class OrderByNullPosition {

--- a/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/model/OrderByNullPosition.kt
+++ b/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/model/OrderByNullPosition.kt
@@ -1,0 +1,16 @@
+package com.saintpatrck.mealie.client.api.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Represents the order direction for sorting.
+ */
+@Serializable
+enum class OrderByNullPosition {
+    @SerialName("first")
+    FIRST,
+
+    @SerialName("last")
+    LAST,
+}

--- a/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/model/OrderDirection.kt
+++ b/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/model/OrderDirection.kt
@@ -1,0 +1,16 @@
+package com.saintpatrck.mealie.client.api.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Represents the order direction for sorting.
+ */
+@Serializable
+enum class OrderDirection {
+    @SerialName("asc")
+    ASC,
+
+    @SerialName("desc")
+    DESC,
+}

--- a/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/model/PagedResponseJson.kt
+++ b/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/model/PagedResponseJson.kt
@@ -1,0 +1,23 @@
+package com.saintpatrck.mealie.client.api.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Represents a paged response from the Mealie API.
+ */
+@Serializable
+data class PagedResponseJson<T>(
+    @SerialName("page")
+    val page: Int,
+    @SerialName("per_page")
+    val perPage: Int,
+    @SerialName("total_pages")
+    val totalPages: Int,
+    @SerialName("items")
+    val items: List<T>,
+    @SerialName("next")
+    val next: String?,
+    @SerialName("previous")
+    val previous: String?,
+)


### PR DESCRIPTION
This commit introduces `PagedResponseJson` to handle paginated responses from the Mealie API. It also adds `OrderDirection` and `OrderByNullPosition` enums for sorting and null handling in API requests.