### PR TITLE
Add getAllUsers method to AdminApi

### DIFF
--- a/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/admin/AdminApi.kt
+++ b/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/admin/AdminApi.kt
@@ -2,9 +2,13 @@ package com.saintpatrck.mealie.client.api.admin
 
 import com.saintpatrck.mealie.client.api.admin.model.UserResponseJson
 import com.saintpatrck.mealie.client.api.model.MealieResponse
+import com.saintpatrck.mealie.client.api.model.OrderByNullPosition
+import com.saintpatrck.mealie.client.api.model.OrderDirection
+import com.saintpatrck.mealie.client.api.model.PagedResponseJson
 import de.jensklingenberg.ktorfit.http.DELETE
 import de.jensklingenberg.ktorfit.http.GET
 import de.jensklingenberg.ktorfit.http.Path
+import de.jensklingenberg.ktorfit.http.Query
 
 /**
  * Represents the API for administering users.
@@ -30,4 +34,23 @@ interface AdminApi {
         @Path("userId")
         userId: String,
     ): MealieResponse<Unit>
+
+    /**
+     * Retrieves all users, from all groups. Results are paginated.
+     */
+    @GET("users")
+    suspend fun getAllUsers(
+        @Query("orderBy")
+        orderBy: String? = null,
+        @Query("orderByNullPosition")
+        orderByNullPosition: OrderByNullPosition? = null,
+        @Query("orderDirection")
+        orderDirection: OrderDirection = OrderDirection.DESC,
+        @Query("queryFilter")
+        queryFilter: String? = null,
+        @Query("page")
+        page: Int = 1,
+        @Query("pageSize")
+        perPage: Int = 50,
+    ): MealieResponse<PagedResponseJson<UserResponseJson>>
 }

--- a/client/src/commonTest/kotlin/com/saintpatrck/mealie/client/api/admin/AdminApiTest.kt
+++ b/client/src/commonTest/kotlin/com/saintpatrck/mealie/client/api/admin/AdminApiTest.kt
@@ -3,6 +3,7 @@ package com.saintpatrck.mealie.client.api.admin
 import com.saintpatrck.mealie.client.api.admin.model.UserResponseJson
 import com.saintpatrck.mealie.client.api.base.BaseApiTest
 import com.saintpatrck.mealie.client.api.model.MealieToken
+import com.saintpatrck.mealie.client.api.model.PagedResponseJson
 import com.saintpatrck.mealie.client.api.model.getOrNull
 import com.saintpatrck.mealie.client.api.registration.model.MealieAuthMethod
 import kotlinx.coroutines.test.runTest
@@ -33,6 +34,19 @@ class AdminApiTest : BaseApiTest() {
                 assertEquals(
                     Unit,
                     response.getOrNull(),
+                )
+            }
+    }
+
+    @Test
+    fun `getAllUsers should deserialize correctly`() = runTest {
+        createTestMealieClient(responseJson = GET_ALL_USERS_RESPONSE_JSON)
+            .adminApi
+            .getAllUsers()
+            .also {
+                assertEquals(
+                    createMockPagedUserResponseJson(),
+                    it.getOrNull(),
                 )
             }
     }
@@ -69,6 +83,21 @@ private val GET_USER_RESPONSE_JSON = """
 """
     .trimIndent()
 
+private val GET_ALL_USERS_RESPONSE_JSON = """
+{
+  "page": 1,
+  "per_page": 10,
+  "total": 0,
+  "total_pages": 0,
+  "items": [
+    $GET_USER_RESPONSE_JSON
+  ],
+  "next": "string",
+  "previous": "string"
+}
+"""
+    .trimIndent()
+
 
 private fun createMockUserResponseJson() = UserResponseJson(
     id = "id",
@@ -97,3 +126,13 @@ private fun createMockUserResponseJson() = UserResponseJson(
     ),
     cacheKey = "cacheKey",
 )
+
+private fun createMockPagedUserResponseJson(): PagedResponseJson<UserResponseJson> =
+    PagedResponseJson(
+        page = 1,
+        perPage = 10,
+        totalPages = 0,
+        items = listOf(createMockUserResponseJson()),
+        next = "string",
+        previous = "string",
+    )


### PR DESCRIPTION
This commit introduces the `getAllUsers` method to the `AdminApi`.

This method allows retrieving all users, from all groups, with pagination and filtering options.

Corresponding tests and response JSON have been added to ensure correct deserialization.