### PR TITLE
Add create user API and model

### DIFF
--- a/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/admin/AdminApi.kt
+++ b/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/admin/AdminApi.kt
@@ -1,12 +1,16 @@
 package com.saintpatrck.mealie.client.api.admin
 
+import com.saintpatrck.mealie.client.api.admin.model.CreateUserRequestJson
 import com.saintpatrck.mealie.client.api.admin.model.UserResponseJson
 import com.saintpatrck.mealie.client.api.model.MealieResponse
 import com.saintpatrck.mealie.client.api.model.OrderByNullPosition
 import com.saintpatrck.mealie.client.api.model.OrderDirection
 import com.saintpatrck.mealie.client.api.model.PagedResponseJson
+import de.jensklingenberg.ktorfit.http.Body
 import de.jensklingenberg.ktorfit.http.DELETE
 import de.jensklingenberg.ktorfit.http.GET
+import de.jensklingenberg.ktorfit.http.Headers
+import de.jensklingenberg.ktorfit.http.POST
 import de.jensklingenberg.ktorfit.http.Path
 import de.jensklingenberg.ktorfit.http.Query
 
@@ -53,4 +57,13 @@ interface AdminApi {
         @Query("pageSize")
         perPage: Int = 50,
     ): MealieResponse<PagedResponseJson<UserResponseJson>>
+
+    /**
+     * Creates a new user.
+     */
+    @Headers("Content-Type: application/json")
+    @POST("users")
+    suspend fun createUser(
+        @Body user: CreateUserRequestJson,
+    ): MealieResponse<UserResponseJson>
 }

--- a/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/admin/model/CreateUserRequestJson.kt
+++ b/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/admin/model/CreateUserRequestJson.kt
@@ -1,0 +1,38 @@
+package com.saintpatrck.mealie.client.api.admin.model
+
+import com.saintpatrck.mealie.client.api.registration.model.MealieAuthMethod
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Represents a user to be created.
+ */
+@Serializable
+data class CreateUserRequestJson(
+    @SerialName("username")
+    val username: String,
+    @SerialName("fullName")
+    val fullName: String,
+    @SerialName("email")
+    val email: String,
+    @SerialName("authMethod")
+    val authMethod: MealieAuthMethod = MealieAuthMethod.MEALIE,
+    @SerialName("admin")
+    val admin: Boolean = false,
+    @SerialName("group")
+    val group: String,
+    @SerialName("household")
+    val household: String,
+    @SerialName("advanced")
+    val advanced: Boolean = false,
+    @SerialName("canInvite")
+    val canInvite: Boolean = false,
+    @SerialName("canManage")
+    val canManage: Boolean = false,
+    @SerialName("canManageHousehold")
+    val canManageHousehold: Boolean = false,
+    @SerialName("canOrganize")
+    val canOrganize: Boolean = false,
+    @SerialName("password")
+    val password: String,
+)

--- a/client/src/commonTest/kotlin/com/saintpatrck/mealie/client/api/admin/AdminApiTest.kt
+++ b/client/src/commonTest/kotlin/com/saintpatrck/mealie/client/api/admin/AdminApiTest.kt
@@ -1,5 +1,6 @@
 package com.saintpatrck.mealie.client.api.admin
 
+import com.saintpatrck.mealie.client.api.admin.model.CreateUserRequestJson
 import com.saintpatrck.mealie.client.api.admin.model.UserResponseJson
 import com.saintpatrck.mealie.client.api.base.BaseApiTest
 import com.saintpatrck.mealie.client.api.model.MealieToken
@@ -14,7 +15,7 @@ class AdminApiTest : BaseApiTest() {
 
     @Test
     fun `getUser should deserialize correctly`() = runTest {
-        createTestMealieClient(responseJson = GET_USER_RESPONSE_JSON)
+        createTestMealieClient(responseJson = USER_RESPONSE_JSON)
             .adminApi
             .getUser("userId")
             .also { response ->
@@ -50,9 +51,38 @@ class AdminApiTest : BaseApiTest() {
                 )
             }
     }
+
+    @Test
+    fun `createUser should deserialize correctly`() = runTest {
+        createTestMealieClient(responseJson = USER_RESPONSE_JSON)
+            .adminApi
+            .createUser(
+                user = CreateUserRequestJson(
+                    username = "username",
+                    fullName = "fullName",
+                    email = "email",
+                    authMethod = MealieAuthMethod.MEALIE,
+                    admin = false,
+                    group = "group",
+                    household = "household",
+                    advanced = false,
+                    canInvite = false,
+                    canManage = false,
+                    canManageHousehold = false,
+                    canOrganize = false,
+                    password = "password",
+                )
+            )
+            .also {
+                assertEquals(
+                    createMockUserResponseJson(),
+                    it.getOrNull(),
+                )
+            }
+    }
 }
 
-private val GET_USER_RESPONSE_JSON = """
+private val USER_RESPONSE_JSON = """
 {
   "id": "id",
   "username": "username",
@@ -90,14 +120,13 @@ private val GET_ALL_USERS_RESPONSE_JSON = """
   "total": 0,
   "total_pages": 0,
   "items": [
-    $GET_USER_RESPONSE_JSON
+    $USER_RESPONSE_JSON
   ],
   "next": "string",
   "previous": "string"
 }
 """
     .trimIndent()
-
 
 private fun createMockUserResponseJson() = UserResponseJson(
     id = "id",


### PR DESCRIPTION
This commit introduces the `CreateUserRequestJson` data class to represent a user to be created. It also adds the `createUser` function to the `AdminApi` interface, allowing for the creation of new users.