### PR TITLE
Add Password API

### DIFF
--- a/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/MealieClient.kt
+++ b/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/MealieClient.kt
@@ -7,6 +7,8 @@ import com.saintpatrck.mealie.client.api.admin.createAdminApi
 import com.saintpatrck.mealie.client.api.auth.AuthApi
 import com.saintpatrck.mealie.client.api.auth.createAuthApi
 import com.saintpatrck.mealie.client.api.model.MealieBearerTokens
+import com.saintpatrck.mealie.client.api.password.PasswordApi
+import com.saintpatrck.mealie.client.api.password.createPasswordApi
 import com.saintpatrck.mealie.client.api.registration.RegistrationApi
 import com.saintpatrck.mealie.client.api.registration.createRegistrationApi
 import com.saintpatrck.mealie.client.api.user.UserApi
@@ -71,6 +73,13 @@ class MealieClient internal constructor(
      */
     val authApi: AuthApi by lazy {
         ktorfit.createAuthApi()
+    }
+
+    /**
+     * The API for resetting a password.
+     */
+    val passwordApi: PasswordApi by lazy {
+        ktorfit.createPasswordApi()
     }
 
     /**

--- a/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/password/PasswordApi.kt
+++ b/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/password/PasswordApi.kt
@@ -1,0 +1,34 @@
+package com.saintpatrck.mealie.client.api.password
+
+import com.saintpatrck.mealie.client.api.model.MealieResponse
+import com.saintpatrck.mealie.client.api.password.model.ForgotPasswordRequestJson
+import com.saintpatrck.mealie.client.api.password.model.ResetPasswordRequestJson
+import de.jensklingenberg.ktorfit.http.Body
+import de.jensklingenberg.ktorfit.http.Headers
+import de.jensklingenberg.ktorfit.http.POST
+
+/**
+ * Represents the API for resetting a password.
+ */
+interface PasswordApi {
+
+    /**
+     * Initiates a password reset by sending a link to a user's email.
+     */
+    @Headers("Content-Type: application/json")
+    @POST("users/forgot-password")
+    suspend fun forgotPassword(
+        @Body
+        forgotPasswordRequest: ForgotPasswordRequestJson,
+    ): MealieResponse<Unit>
+
+    /**
+     * Resets a password.
+     */
+    @Headers("Content-Type: application/json")
+    @POST("users/reset-password")
+    suspend fun resetPassword(
+        @Body
+        resetPasswordRequest: ResetPasswordRequestJson,
+    ): MealieResponse<Unit>
+}

--- a/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/password/model/ForgotPasswordRequestJson.kt
+++ b/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/password/model/ForgotPasswordRequestJson.kt
@@ -1,0 +1,15 @@
+package com.saintpatrck.mealie.client.api.password.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Represents a request to send a password reset link to a given [email] if it belongs to a user.
+ *
+ * @property email The email address to send the reset link to.
+ */
+@Serializable
+data class ForgotPasswordRequestJson(
+    @SerialName("email")
+    val email: String,
+)

--- a/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/password/model/ResetPasswordRequestJson.kt
+++ b/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/password/model/ResetPasswordRequestJson.kt
@@ -1,0 +1,24 @@
+package com.saintpatrck.mealie.client.api.password.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Represents a request to reset a password.
+ *
+ * @property token The token to reset the password with.
+ * @property email The email address to reset the password for.
+ * @property password The new password.
+ * @property passwordConfirm The new password confirmation.
+ */
+@Serializable
+data class ResetPasswordRequestJson(
+    @SerialName("token")
+    val token: String,
+    @SerialName("email")
+    val email: String,
+    @SerialName("password")
+    val password: String,
+    @SerialName("passwordConfirm")
+    val passwordConfirm: String,
+)

--- a/client/src/commonTest/kotlin/com/saintpatrck/mealie/client/api/password/PasswordApiTest.kt
+++ b/client/src/commonTest/kotlin/com/saintpatrck/mealie/client/api/password/PasswordApiTest.kt
@@ -1,0 +1,49 @@
+package com.saintpatrck.mealie.client.api.password
+
+import com.saintpatrck.mealie.client.api.base.BaseApiTest
+import com.saintpatrck.mealie.client.api.model.getOrNull
+import com.saintpatrck.mealie.client.api.password.model.ForgotPasswordRequestJson
+import com.saintpatrck.mealie.client.api.password.model.ResetPasswordRequestJson
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class PasswordApiTest : BaseApiTest() {
+
+    @Test
+    fun `forgotPassword should deserialize correctly`() = runTest {
+        createTestMealieClient(responseJson = "")
+            .passwordApi
+            .forgotPassword(
+                forgotPasswordRequest = ForgotPasswordRequestJson(
+                    email = "email",
+                )
+            )
+            .also {
+                assertEquals(
+                    Unit,
+                    it.getOrNull(),
+                )
+            }
+    }
+
+    @Test
+    fun `resetPassword should deserialize correctly`() = runTest {
+        createTestMealieClient(responseJson = "")
+            .passwordApi
+            .resetPassword(
+                resetPasswordRequest = ResetPasswordRequestJson(
+                    token = "token",
+                    email = "email",
+                    password = "password",
+                    passwordConfirm = "passwordConfirm",
+                )
+            )
+            .also {
+                assertEquals(
+                    Unit,
+                    it.getOrNull(),
+                )
+            }
+    }
+}


### PR DESCRIPTION
This commit introduces the `PasswordApi` for handling password reset functionality.

It includes:
- `PasswordApi` interface with `forgotPassword` and `resetPassword` methods.
- Data models `ForgotPasswordRequestJson` and `ResetPasswordRequestJson`.
- Integration of `PasswordApi` into `MealieClient`.
- Unit tests for `PasswordApi` methods.