### PR TITLE
Add `createApiToken` endpoint and models

### DIFF
--- a/client/build.gradle.kts
+++ b/client/build.gradle.kts
@@ -51,6 +51,7 @@ kotlin {
         }
         commonMain.dependencies {
             implementation(libs.kotlinx.coroutines.core)
+            implementation(libs.kotlinx.datetime)
             implementation(libs.kotlinx.serialization.json)
             implementation(libs.ktor.client.auth)
             implementation(libs.ktor.client.content.negotiation)

--- a/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/user/UserApi.kt
+++ b/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/user/UserApi.kt
@@ -6,6 +6,8 @@ import com.saintpatrck.mealie.client.api.model.OrderByNullPosition
 import com.saintpatrck.mealie.client.api.model.OrderDirection
 import com.saintpatrck.mealie.client.api.model.PagedResponseJson
 import com.saintpatrck.mealie.client.api.model.Rating
+import com.saintpatrck.mealie.client.api.user.model.CreateApiTokenRequestJson
+import com.saintpatrck.mealie.client.api.user.model.CreateApiTokenResponseJson
 import com.saintpatrck.mealie.client.api.user.model.CreateUserRequestJson
 import com.saintpatrck.mealie.client.api.user.model.ForgotPasswordRequestJson
 import com.saintpatrck.mealie.client.api.user.model.RegisterUserRequestJson
@@ -159,4 +161,14 @@ interface UserApi {
         @Body
         resetPasswordRequest: ResetPasswordRequestJson,
     ): MealieResponse<Unit>
+
+    /**
+     * Creates a new API token for the current user.
+     */
+    @Headers("Content-Type: application/json")
+    @POST("users/api-tokens")
+    suspend fun createApiToken(
+        @Body
+        createApiTokenRequestJson: CreateApiTokenRequestJson,
+    ): MealieResponse<CreateApiTokenResponseJson>
 }

--- a/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/user/model/CreateApiTokenRequestJson.kt
+++ b/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/user/model/CreateApiTokenRequestJson.kt
@@ -1,0 +1,18 @@
+package com.saintpatrck.mealie.client.api.user.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Represents a request to create an API token.
+ *
+ * @property name The name of the API token.
+ * @property integrationId The ID of the integration associated with the API token.
+ */
+@Serializable
+data class CreateApiTokenRequestJson(
+    @SerialName("name")
+    val name: String,
+    @SerialName("integrationId")
+    val integrationId: String,
+)

--- a/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/user/model/CreateApiTokenResponseJson.kt
+++ b/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/user/model/CreateApiTokenResponseJson.kt
@@ -1,0 +1,25 @@
+package com.saintpatrck.mealie.client.api.user.model
+
+import kotlinx.datetime.Instant
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Models a response from creating an API token.
+ *
+ * @property name The name of the API token.
+ * @property id The ID of the API token.
+ * @property createdAt The date and time when the API token was created.
+ * @property token The token value.
+ */
+@Serializable
+data class CreateApiTokenResponseJson(
+    @SerialName("name")
+    val name: String,
+    @SerialName("id")
+    val id: Int,
+    @SerialName("createdAt")
+    val createdAt: Instant,
+    @SerialName("token")
+    val token: String,
+)

--- a/client/src/commonTest/kotlin/com/saintpatrck/mealie/client/api/user/UserApiTest.kt
+++ b/client/src/commonTest/kotlin/com/saintpatrck/mealie/client/api/user/UserApiTest.kt
@@ -5,6 +5,8 @@ import com.saintpatrck.mealie.client.api.model.MealieToken
 import com.saintpatrck.mealie.client.api.model.PagedResponseJson
 import com.saintpatrck.mealie.client.api.model.Rating
 import com.saintpatrck.mealie.client.api.model.getOrNull
+import com.saintpatrck.mealie.client.api.user.model.CreateApiTokenRequestJson
+import com.saintpatrck.mealie.client.api.user.model.CreateApiTokenResponseJson
 import com.saintpatrck.mealie.client.api.user.model.CreateUserRequestJson
 import com.saintpatrck.mealie.client.api.user.model.ForgotPasswordRequestJson
 import com.saintpatrck.mealie.client.api.user.model.MealieAuthMethod
@@ -18,6 +20,7 @@ import com.saintpatrck.mealie.client.api.user.model.UpdatePasswordRequestJson
 import com.saintpatrck.mealie.client.api.user.model.UpdateUserRequestJson
 import com.saintpatrck.mealie.client.api.user.model.UserResponseJson
 import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.Instant
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -255,9 +258,36 @@ class UserApiTest : BaseApiTest() {
                 )
             }
     }
+
+    @Test
+    fun `createApiToken should deserialize correctly`() = runTest {
+        createTestMealieClient(responseJson = CREATE_API_TOKEN_RESPONSE_JSON)
+            .userApi
+            .createApiToken(
+                createApiTokenRequestJson = CreateApiTokenRequestJson(
+                    name = "name",
+                    integrationId = "integrationId",
+                )
+            )
+            .also { response ->
+                assertEquals(
+                    createMockCreateApiTokenResponse(),
+                    response.getOrNull(),
+                )
+            }
+    }
 }
 
-private const val REGISTER_USER_RESPONSE_JSON = """
+private val CREATE_API_TOKEN_RESPONSE_JSON = """
+{
+  "name": "name",
+  "id": 0,
+  "createdAt": "2019-08-24T14:15:22Z",
+  "token": "token"
+} 
+"""
+    .trimIndent()
+private val REGISTER_USER_RESPONSE_JSON = """
 {
   "username": "username",
   "email": "test@email.com",
@@ -286,6 +316,7 @@ private const val REGISTER_USER_RESPONSE_JSON = """
   "cacheKey": "cacheKey"
 }
 """
+    .trimIndent()
 private val SELF_RESPONSE_JSON = """
 {
   "username": "username",
@@ -510,4 +541,11 @@ fun createMockRegisterUserResponseJson() = RegisterUserResponseJson(
         )
     ),
     cacheKey = "cacheKey",
+)
+
+fun createMockCreateApiTokenResponse() = CreateApiTokenResponseJson(
+    name = "name",
+    id = 0,
+    createdAt = Instant.parse("2019-08-24T14:15:22Z"),
+    token = "token",
 )

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,6 +8,7 @@ jvmTarget = "1.8"
 kotlin = "2.1.21"
 kotlinGradlePlugin = "2.1.0"
 kotlinxCoroutines = "1.10.2"
+kotlinxDateTime = "0.6.2"
 kotlinxSerialization = "1.8.1"
 ksp = "2.1.21-2.0.1"
 ktor = "3.1.3"
@@ -21,6 +22,7 @@ kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotl
 kotlinx-coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "kotlinxCoroutines" }
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinxCoroutines" }
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinxCoroutines" }
+kotlinx-datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version.ref = "kotlinxDateTime" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinxSerialization" }
 ktor-client-auth = { module = "io.ktor:ktor-client-auth", version.ref = "ktor" }
 ktor-client-content-negotiation = { module = "io.ktor:ktor-client-content-negotiation", version.ref = "ktor" }


### PR DESCRIPTION
This commit introduces the `createApiToken` endpoint to the `UserApi` along with its request and response models (`CreateApiTokenRequestJson` and `CreateApiTokenResponseJson`).

Tests for the new endpoint have also been added.