### PR TITLE
Add API token deletion functionality

### DIFF
--- a/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/user/UserApi.kt
+++ b/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/user/UserApi.kt
@@ -9,6 +9,7 @@ import com.saintpatrck.mealie.client.api.model.Rating
 import com.saintpatrck.mealie.client.api.user.model.CreateApiTokenRequestJson
 import com.saintpatrck.mealie.client.api.user.model.CreateApiTokenResponseJson
 import com.saintpatrck.mealie.client.api.user.model.CreateUserRequestJson
+import com.saintpatrck.mealie.client.api.user.model.DeleteTokenResponseJson
 import com.saintpatrck.mealie.client.api.user.model.ForgotPasswordRequestJson
 import com.saintpatrck.mealie.client.api.user.model.RegisterUserRequestJson
 import com.saintpatrck.mealie.client.api.user.model.RegisterUserResponseJson
@@ -171,4 +172,13 @@ interface UserApi {
         @Body
         createApiTokenRequestJson: CreateApiTokenRequestJson,
     ): MealieResponse<CreateApiTokenResponseJson>
+
+    /**
+     * Deletes an API token for the current user.
+     */
+    @DELETE("users/api-tokens/{tokenId}")
+    suspend fun deleteApiToken(
+        @Path("tokenId")
+        token: Int,
+    ): MealieResponse<DeleteTokenResponseJson>
 }

--- a/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/user/model/DeleteTokenResponseJson.kt
+++ b/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/user/model/DeleteTokenResponseJson.kt
@@ -1,0 +1,15 @@
+package com.saintpatrck.mealie.client.api.user.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Models the response when deleting an API token.
+ *
+ * @property tokenDelete The token that was deleted.
+ */
+@Serializable
+data class DeleteTokenResponseJson(
+    @SerialName("tokenDelete")
+    val tokenDelete: String,
+)

--- a/client/src/commonTest/kotlin/com/saintpatrck/mealie/client/api/user/UserApiTest.kt
+++ b/client/src/commonTest/kotlin/com/saintpatrck/mealie/client/api/user/UserApiTest.kt
@@ -8,6 +8,7 @@ import com.saintpatrck.mealie.client.api.model.getOrNull
 import com.saintpatrck.mealie.client.api.user.model.CreateApiTokenRequestJson
 import com.saintpatrck.mealie.client.api.user.model.CreateApiTokenResponseJson
 import com.saintpatrck.mealie.client.api.user.model.CreateUserRequestJson
+import com.saintpatrck.mealie.client.api.user.model.DeleteTokenResponseJson
 import com.saintpatrck.mealie.client.api.user.model.ForgotPasswordRequestJson
 import com.saintpatrck.mealie.client.api.user.model.MealieAuthMethod
 import com.saintpatrck.mealie.client.api.user.model.RegisterUserRequestJson
@@ -276,8 +277,27 @@ class UserApiTest : BaseApiTest() {
                 )
             }
     }
+
+    @Test
+    fun `deleteApiToken should deserialize correctly`() = runTest {
+        createTestMealieClient(responseJson = DELETE_TOKEN_RESPONSE_JSON)
+            .userApi
+            .deleteApiToken(1)
+            .also { response ->
+                assertEquals(
+                    createMockDeleteJsonResponse(),
+                    response.getOrNull(),
+                )
+            }
+    }
 }
 
+private val DELETE_TOKEN_RESPONSE_JSON = """
+{
+  "tokenDelete": "tokenDelete"
+}
+"""
+    .trimIndent()
 private val CREATE_API_TOKEN_RESPONSE_JSON = """
 {
   "name": "name",
@@ -548,4 +568,8 @@ fun createMockCreateApiTokenResponse() = CreateApiTokenResponseJson(
     id = 0,
     createdAt = Instant.parse("2019-08-24T14:15:22Z"),
     token = "token",
+)
+
+fun createMockDeleteJsonResponse() = DeleteTokenResponseJson(
+    tokenDelete = "tokenDelete",
 )


### PR DESCRIPTION
This commit introduces the ability to delete API tokens.

- Added `DeleteTokenResponseJson` data class to model the API response.
- Implemented `deleteApiToken` suspend function in `UserApi` to handle the deletion request.
- Added a corresponding test case in `UserApiTest` to verify the functionality and deserialization of the response.