### PR TITLE
Add `getRatingsForUser(userId)` to fetch ratings for a specific user

### DIFF
--- a/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/user/UserApi.kt
+++ b/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/user/UserApi.kt
@@ -11,11 +11,11 @@ import com.saintpatrck.mealie.client.api.user.model.CreateApiTokenResponseJson
 import com.saintpatrck.mealie.client.api.user.model.CreateUserRequestJson
 import com.saintpatrck.mealie.client.api.user.model.DeleteTokenResponseJson
 import com.saintpatrck.mealie.client.api.user.model.ForgotPasswordRequestJson
+import com.saintpatrck.mealie.client.api.user.model.RatingsResponseJson
 import com.saintpatrck.mealie.client.api.user.model.RegisterUserRequestJson
 import com.saintpatrck.mealie.client.api.user.model.RegisterUserResponseJson
 import com.saintpatrck.mealie.client.api.user.model.ResetPasswordRequestJson
 import com.saintpatrck.mealie.client.api.user.model.SelfFavoritesResponseJson
-import com.saintpatrck.mealie.client.api.user.model.SelfRatingsResponseJson
 import com.saintpatrck.mealie.client.api.user.model.SelfResponseJson
 import com.saintpatrck.mealie.client.api.user.model.UpdatePasswordRequestJson
 import com.saintpatrck.mealie.client.api.user.model.UpdateUserRequestJson
@@ -52,7 +52,7 @@ interface UserApi {
      * Retrieves the current user's rated recipes.
      */
     @GET("users/self/ratings")
-    suspend fun ratings(): MealieResponse<SelfRatingsResponseJson>
+    suspend fun ratings(): MealieResponse<RatingsResponseJson>
 
     /**
      * Retrieves the current user's rating for a specific recipe.
@@ -181,4 +181,13 @@ interface UserApi {
         @Path("tokenId")
         token: Int,
     ): MealieResponse<DeleteTokenResponseJson>
+
+    /**
+     * Get ratings for the user with the given [userId].
+     */
+    @GET("users/{userId}/ratings")
+    suspend fun getRatingsForUser(
+        @Path("userId")
+        userId: String,
+    ): MealieResponse<RatingsResponseJson>
 }

--- a/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/user/model/RatingsResponseJson.kt
+++ b/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/user/model/RatingsResponseJson.kt
@@ -5,12 +5,12 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 /**
- * Represents the response from the /users/self/ratings endpoint.
+ * Models a collection of [Rating].
  *
  * @property ratings The list of ratings.
  */
 @Serializable
-data class SelfRatingsResponseJson(
+data class RatingsResponseJson(
     @SerialName("ratings")
     val ratings: List<Rating>,
 )

--- a/client/src/commonTest/kotlin/com/saintpatrck/mealie/client/api/user/UserApiTest.kt
+++ b/client/src/commonTest/kotlin/com/saintpatrck/mealie/client/api/user/UserApiTest.kt
@@ -11,11 +11,11 @@ import com.saintpatrck.mealie.client.api.user.model.CreateUserRequestJson
 import com.saintpatrck.mealie.client.api.user.model.DeleteTokenResponseJson
 import com.saintpatrck.mealie.client.api.user.model.ForgotPasswordRequestJson
 import com.saintpatrck.mealie.client.api.user.model.MealieAuthMethod
+import com.saintpatrck.mealie.client.api.user.model.RatingsResponseJson
 import com.saintpatrck.mealie.client.api.user.model.RegisterUserRequestJson
 import com.saintpatrck.mealie.client.api.user.model.RegisterUserResponseJson
 import com.saintpatrck.mealie.client.api.user.model.ResetPasswordRequestJson
 import com.saintpatrck.mealie.client.api.user.model.SelfFavoritesResponseJson
-import com.saintpatrck.mealie.client.api.user.model.SelfRatingsResponseJson
 import com.saintpatrck.mealie.client.api.user.model.SelfResponseJson
 import com.saintpatrck.mealie.client.api.user.model.UpdatePasswordRequestJson
 import com.saintpatrck.mealie.client.api.user.model.UpdateUserRequestJson
@@ -42,12 +42,12 @@ class UserApiTest : BaseApiTest() {
 
     @Test
     fun `ratings should deserialize correctly`() = runTest {
-        createTestMealieClient(responseJson = SELF_RATINGS_RESPONSE_JSON)
+        createTestMealieClient(responseJson = RATINGS_RESPONSE_JSON)
             .userApi
             .ratings()
             .also { response ->
                 assertEquals(
-                    createMockSelfRatingsResponseJson(),
+                    createMockRatingsResponseJson(),
                     response.getOrNull(),
                 )
             }
@@ -290,6 +290,19 @@ class UserApiTest : BaseApiTest() {
                 )
             }
     }
+
+    @Test
+    fun `getRatingsForUser should deserialize correctly`() = runTest {
+        createTestMealieClient(responseJson = RATINGS_RESPONSE_JSON)
+            .userApi
+            .getRatingsForUser("userId")
+            .also { response ->
+                assertEquals(
+                    createMockRatingsResponseJson(),
+                    response.getOrNull(),
+                )
+            }
+    }
 }
 
 private val DELETE_TOKEN_RESPONSE_JSON = """
@@ -367,7 +380,7 @@ private val SELF_RESPONSE_JSON = """
 }
 """
     .trimIndent()
-private val SELF_RATINGS_RESPONSE_JSON = """
+private val RATINGS_RESPONSE_JSON = """
 {
   "ratings": [
     {
@@ -509,7 +522,7 @@ private fun createMockSelfResponseJson() = SelfResponseJson(
     cacheKey = "cacheKey",
 )
 
-private fun createMockSelfRatingsResponseJson() = SelfRatingsResponseJson(
+private fun createMockRatingsResponseJson() = RatingsResponseJson(
     ratings = listOf(
         Rating(
             recipeId = "recipeId",


### PR DESCRIPTION
This commit introduces the ability to retrieve ratings for a specified user.

Additionally, this commit introduces the following changes:

- Renamed `SelfRatingsResponseJson` to `RatingsResponseJson` for clarity and broader applicability.
- Updated `UserApi.ratings()` to return `RatingsResponseJson`.
- Updated corresponding tests to reflect these changes.