### PR TITLE
Add `getFavoritesForUser` to retrieve favorites for a specified user

### DIFF
--- a/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/user/UserApi.kt
+++ b/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/user/UserApi.kt
@@ -10,12 +10,12 @@ import com.saintpatrck.mealie.client.api.user.model.CreateApiTokenRequestJson
 import com.saintpatrck.mealie.client.api.user.model.CreateApiTokenResponseJson
 import com.saintpatrck.mealie.client.api.user.model.CreateUserRequestJson
 import com.saintpatrck.mealie.client.api.user.model.DeleteTokenResponseJson
+import com.saintpatrck.mealie.client.api.user.model.FavoritesResponseJson
 import com.saintpatrck.mealie.client.api.user.model.ForgotPasswordRequestJson
 import com.saintpatrck.mealie.client.api.user.model.RatingsResponseJson
 import com.saintpatrck.mealie.client.api.user.model.RegisterUserRequestJson
 import com.saintpatrck.mealie.client.api.user.model.RegisterUserResponseJson
 import com.saintpatrck.mealie.client.api.user.model.ResetPasswordRequestJson
-import com.saintpatrck.mealie.client.api.user.model.SelfFavoritesResponseJson
 import com.saintpatrck.mealie.client.api.user.model.SelfResponseJson
 import com.saintpatrck.mealie.client.api.user.model.UpdatePasswordRequestJson
 import com.saintpatrck.mealie.client.api.user.model.UpdateUserRequestJson
@@ -71,7 +71,7 @@ interface UserApi {
      * Retrieves the current user's favorite recipes.
      */
     @GET("users/self/favorites")
-    suspend fun favorites(): MealieResponse<SelfFavoritesResponseJson>
+    suspend fun favorites(): MealieResponse<FavoritesResponseJson>
 
     /**
      * Changes the current user's password.
@@ -190,4 +190,13 @@ interface UserApi {
         @Path("userId")
         userId: String,
     ): MealieResponse<RatingsResponseJson>
+
+    /**
+     * Get favorites for the user with the given [userId].
+     */
+    @GET("users/{userId}/favorites")
+    suspend fun getFavoritesForUser(
+        @Path("userId")
+        userId: String,
+    ): MealieResponse<FavoritesResponseJson>
 }

--- a/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/user/model/FavoritesResponseJson.kt
+++ b/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/user/model/FavoritesResponseJson.kt
@@ -5,12 +5,12 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 /**
- * Represents the response from the /users/self/favorites endpoint.
+ * Models a collection of user's favorites recipes.
  *
  * @property ratings The list of users favorite recipes.
  */
 @Serializable
-data class SelfFavoritesResponseJson(
+data class FavoritesResponseJson(
     @SerialName("ratings")
     val ratings: List<Rating>,
 )

--- a/client/src/commonTest/kotlin/com/saintpatrck/mealie/client/api/user/UserApiTest.kt
+++ b/client/src/commonTest/kotlin/com/saintpatrck/mealie/client/api/user/UserApiTest.kt
@@ -9,13 +9,13 @@ import com.saintpatrck.mealie.client.api.user.model.CreateApiTokenRequestJson
 import com.saintpatrck.mealie.client.api.user.model.CreateApiTokenResponseJson
 import com.saintpatrck.mealie.client.api.user.model.CreateUserRequestJson
 import com.saintpatrck.mealie.client.api.user.model.DeleteTokenResponseJson
+import com.saintpatrck.mealie.client.api.user.model.FavoritesResponseJson
 import com.saintpatrck.mealie.client.api.user.model.ForgotPasswordRequestJson
 import com.saintpatrck.mealie.client.api.user.model.MealieAuthMethod
 import com.saintpatrck.mealie.client.api.user.model.RatingsResponseJson
 import com.saintpatrck.mealie.client.api.user.model.RegisterUserRequestJson
 import com.saintpatrck.mealie.client.api.user.model.RegisterUserResponseJson
 import com.saintpatrck.mealie.client.api.user.model.ResetPasswordRequestJson
-import com.saintpatrck.mealie.client.api.user.model.SelfFavoritesResponseJson
 import com.saintpatrck.mealie.client.api.user.model.SelfResponseJson
 import com.saintpatrck.mealie.client.api.user.model.UpdatePasswordRequestJson
 import com.saintpatrck.mealie.client.api.user.model.UpdateUserRequestJson
@@ -68,12 +68,12 @@ class UserApiTest : BaseApiTest() {
 
     @Test
     fun `favorites should deserialize correctly`() = runTest {
-        createTestMealieClient(responseJson = SELF_FAVORITES_RESPONSE_JSON)
+        createTestMealieClient(responseJson = FAVORITES_RESPONSE_JSON)
             .userApi
             .favorites()
             .also { response ->
                 assertEquals(
-                    createMockSelfFavoritesResponseJson(),
+                    createMockFavoritesResponseJson(),
                     response.getOrNull(),
                 )
             }
@@ -303,6 +303,19 @@ class UserApiTest : BaseApiTest() {
                 )
             }
     }
+
+    @Test
+    fun `getFavoritesForUser should deserialize correctly`() = runTest {
+        createTestMealieClient(responseJson = FAVORITES_RESPONSE_JSON)
+            .userApi
+            .getFavoritesForUser("userId")
+            .also { response ->
+                assertEquals(
+                    createMockFavoritesResponseJson(),
+                    response.getOrNull(),
+                )
+            }
+    }
 }
 
 private val DELETE_TOKEN_RESPONSE_JSON = """
@@ -400,7 +413,7 @@ private val SELF_RATING_FOR_RECIPE_RESPONSE_JSON = """
 }
 """
     .trimIndent()
-private val SELF_FAVORITES_RESPONSE_JSON = """
+private val FAVORITES_RESPONSE_JSON = """
 {
   "ratings": [
     {
@@ -538,7 +551,7 @@ private fun createMockRatingForRecipeResponseJson() = Rating(
     isFavorite = false,
 )
 
-private fun createMockSelfFavoritesResponseJson() = SelfFavoritesResponseJson(
+private fun createMockFavoritesResponseJson() = FavoritesResponseJson(
     ratings = listOf(
         Rating(
             recipeId = "recipeId",


### PR DESCRIPTION
This commit adds a new `getFavoritesForUser()` method to `UserApi` to fetch favorites for a specific user ID.

Additionally, the following changes were made:
- Renamed `SelfFavoritesResponseJson` to `FavoritesResponseJson` for better clarity.
- Updated the `favorites()` method in `UserApi` to use `FavoritesResponseJson`.
- Updated tests to reflect these changes.