### PR TITLE
Add `setRating` API to UserApi

### DIFF
--- a/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/user/UserApi.kt
+++ b/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/user/UserApi.kt
@@ -17,6 +17,7 @@ import com.saintpatrck.mealie.client.api.user.model.RegisterUserRequestJson
 import com.saintpatrck.mealie.client.api.user.model.RegisterUserResponseJson
 import com.saintpatrck.mealie.client.api.user.model.ResetPasswordRequestJson
 import com.saintpatrck.mealie.client.api.user.model.SelfResponseJson
+import com.saintpatrck.mealie.client.api.user.model.SetRatingRequestJson
 import com.saintpatrck.mealie.client.api.user.model.UpdatePasswordRequestJson
 import com.saintpatrck.mealie.client.api.user.model.UpdateUserRequestJson
 import com.saintpatrck.mealie.client.api.user.model.UserResponseJson
@@ -199,4 +200,22 @@ interface UserApi {
         @Path("userId")
         userId: String,
     ): MealieResponse<FavoritesResponseJson>
+
+    /**
+     * Set the user's rating for a recipe.
+     *
+     * @param userId The ID of the user.
+     * @param recipeId The ID of the recipe.
+     * @param rating The rating to set.
+     */
+    @Headers("Content-Type: application/json")
+    @POST("users/{userId}/ratings/{recipeId}")
+    suspend fun setRating(
+        @Path("userId")
+        userId: String,
+        @Path("recipeId")
+        recipeId: String,
+        @Body
+        rating: SetRatingRequestJson,
+    ): MealieResponse<Unit>
 }

--- a/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/user/model/SetRatingRequestJson.kt
+++ b/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/user/model/SetRatingRequestJson.kt
@@ -1,0 +1,15 @@
+package com.saintpatrck.mealie.client.api.user.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Models a request to set the rating for a recipe.
+ */
+@Serializable
+data class SetRatingRequestJson(
+    @SerialName("rating")
+    val rating: Double,
+    @SerialName("isFavorite")
+    val isFavorite: Boolean,
+)

--- a/client/src/commonTest/kotlin/com/saintpatrck/mealie/client/api/user/UserApiTest.kt
+++ b/client/src/commonTest/kotlin/com/saintpatrck/mealie/client/api/user/UserApiTest.kt
@@ -17,6 +17,7 @@ import com.saintpatrck.mealie.client.api.user.model.RegisterUserRequestJson
 import com.saintpatrck.mealie.client.api.user.model.RegisterUserResponseJson
 import com.saintpatrck.mealie.client.api.user.model.ResetPasswordRequestJson
 import com.saintpatrck.mealie.client.api.user.model.SelfResponseJson
+import com.saintpatrck.mealie.client.api.user.model.SetRatingRequestJson
 import com.saintpatrck.mealie.client.api.user.model.UpdatePasswordRequestJson
 import com.saintpatrck.mealie.client.api.user.model.UpdateUserRequestJson
 import com.saintpatrck.mealie.client.api.user.model.UserResponseJson
@@ -312,6 +313,26 @@ class UserApiTest : BaseApiTest() {
             .also { response ->
                 assertEquals(
                     createMockFavoritesResponseJson(),
+                    response.getOrNull(),
+                )
+            }
+    }
+
+    @Test
+    fun `setRating should deserialize correctly`() = runTest {
+        createTestMealieClient(responseJson = "")
+            .userApi
+            .setRating(
+                userId = "userId",
+                recipeId = "recipeId",
+                rating = SetRatingRequestJson(
+                    rating = 1.0,
+                    isFavorite = false,
+                ),
+            )
+            .also { response ->
+                assertEquals(
+                    Unit,
                     response.getOrNull(),
                 )
             }


### PR DESCRIPTION
This commit introduces the `setRating` endpoint to the `UserApi`, allowing users to set a rating and mark a recipe as a favorite.

It includes:
- The `SetRatingRequestJson` data class for the request body.
- The `setRating` function in the `UserApi` interface.
- A corresponding test case in `UserApiTest` to ensure correct deserialization of an empty response