### PR TITLE
Add UserApi.addFavorite and test deserialization

### DIFF
--- a/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/user/UserApi.kt
+++ b/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/user/UserApi.kt
@@ -218,4 +218,18 @@ interface UserApi {
         @Body
         rating: SetRatingRequestJson,
     ): MealieResponse<Unit>
+
+    /**
+     * Add a recipe to the user's favorites.
+     *
+     * @param userId The ID of the user.
+     * @param recipeId The ID of the recipe.
+     */
+    @POST("users/{userId}/favorites/{recipeId}")
+    suspend fun addFavorite(
+        @Path("userId")
+        userId: String,
+        @Path("recipeId")
+        recipeId: String,
+    ): MealieResponse<Unit>
 }

--- a/client/src/commonTest/kotlin/com/saintpatrck/mealie/client/api/user/UserApiTest.kt
+++ b/client/src/commonTest/kotlin/com/saintpatrck/mealie/client/api/user/UserApiTest.kt
@@ -337,6 +337,22 @@ class UserApiTest : BaseApiTest() {
                 )
             }
     }
+
+    @Test
+    fun `addFavorite should deserialize correctly`() = runTest {
+        createTestMealieClient(responseJson = "")
+            .userApi
+            .addFavorite(
+                userId = "userId",
+                recipeId = "recipeId",
+            )
+            .also { response ->
+                assertEquals(
+                    Unit,
+                    response.getOrNull(),
+                )
+            }
+    }
 }
 
 private val DELETE_TOKEN_RESPONSE_JSON = """


### PR DESCRIPTION
This commit introduces the `addFavorite` function to the `UserApi`. This function allows adding a recipe to a user's favorites.

A corresponding test, `addFavorite should deserialize correctly`, has been added to `UserApiTest.kt` to ensure the response is deserialized as `Unit` when the API call is successful (indicated by an empty JSON response).