### PR TITLE
Add households API with cookbook retrieval

### DIFF
--- a/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/MealieClient.kt
+++ b/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/MealieClient.kt
@@ -4,6 +4,8 @@ import com.saintpatrck.mealie.client.api.about.AboutApi
 import com.saintpatrck.mealie.client.api.about.createAboutApi
 import com.saintpatrck.mealie.client.api.auth.AuthApi
 import com.saintpatrck.mealie.client.api.auth.createAuthApi
+import com.saintpatrck.mealie.client.api.households.HouseholdsApi
+import com.saintpatrck.mealie.client.api.households.createHouseholdsApi
 import com.saintpatrck.mealie.client.api.model.MealieBearerTokens
 import com.saintpatrck.mealie.client.api.user.UserApi
 import com.saintpatrck.mealie.client.api.user.createUserApi
@@ -67,5 +69,12 @@ class MealieClient internal constructor(
      */
     val userApi: UserApi by lazy {
         ktorfit.createUserApi()
+    }
+
+    /**
+     * The API for managing household information.
+     */
+    val householdsApi: HouseholdsApi by lazy {
+        ktorfit.createHouseholdsApi()
     }
 }

--- a/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/households/HouseholdsApi.kt
+++ b/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/households/HouseholdsApi.kt
@@ -1,0 +1,18 @@
+package com.saintpatrck.mealie.client.api.households
+
+import com.saintpatrck.mealie.client.api.households.model.CookbooksResponseJson
+import com.saintpatrck.mealie.client.api.model.MealieResponse
+import com.saintpatrck.mealie.client.api.model.PagedResponseJson
+import de.jensklingenberg.ktorfit.http.GET
+
+/**
+ * API for managing household information.
+ */
+interface HouseholdsApi {
+
+    /**
+     * Retrieves a list of cookbooks.
+     */
+    @GET("households/cookbooks")
+    suspend fun getCookbooks(): MealieResponse<PagedResponseJson<CookbooksResponseJson>>
+}

--- a/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/households/model/CookbooksResponseJson.kt
+++ b/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/households/model/CookbooksResponseJson.kt
@@ -1,0 +1,29 @@
+package com.saintpatrck.mealie.client.api.households.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Models a cookbook.
+ */
+@Serializable
+data class CookbooksResponseJson(
+    @SerialName("name")
+    val name: String,
+    @SerialName("description")
+    val description: String,
+    @SerialName("slug")
+    val slug: String,
+    @SerialName("position")
+    val position: Int,
+    @SerialName("public")
+    val public: Boolean,
+    @SerialName("queryFilterString")
+    val queryFilterString: String,
+    @SerialName("groupId")
+    val groupId: String,
+    @SerialName("householdId")
+    val householdId: String,
+    @SerialName("id")
+    val id: String,
+)

--- a/client/src/commonTest/kotlin/com/saintpatrck/mealie/client/api/households/HouseholdsApiTest.kt
+++ b/client/src/commonTest/kotlin/com/saintpatrck/mealie/client/api/households/HouseholdsApiTest.kt
@@ -1,0 +1,74 @@
+package com.saintpatrck.mealie.client.api.households
+
+import com.saintpatrck.mealie.client.api.base.BaseApiTest
+import com.saintpatrck.mealie.client.api.households.model.CookbooksResponseJson
+import com.saintpatrck.mealie.client.api.model.PagedResponseJson
+import com.saintpatrck.mealie.client.api.model.getOrNull
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class HouseholdsApiTest : BaseApiTest() {
+
+    @Test
+    fun `getCookbooks should deserialize correctly`() = runTest {
+        createTestMealieClient(responseJson = GET_COOKBOOKS_RESPONSE_JSON)
+            .householdsApi
+            .getCookbooks()
+            .also { response ->
+                assertEquals(
+                    createMockPagedCookbooksResponseJson(),
+                    response.getOrNull(),
+                )
+            }
+    }
+}
+
+private val GET_COOKBOOKS_RESPONSE_JSON = """
+{
+  "page": 1,
+  "per_page": 10,
+  "total": 0,
+  "total_pages": 0,
+  "items": [
+    {
+      "name": "name",
+      "description": "description",
+      "slug": "slug",
+      "position": 1,
+      "public": false,
+      "queryFilterString": "queryFilterString",
+      "groupId": "groupId",
+      "householdId": "householdId",
+      "id": "id",
+      "queryFilter": {
+        "parts": []
+      }
+    }
+  ],
+  "next": "next",
+  "previous": "previous"
+}
+"""
+    .trimIndent()
+
+private fun createMockPagedCookbooksResponseJson() = PagedResponseJson(
+    page = 1,
+    perPage = 10,
+    totalPages = 0,
+    items = listOf(createMockCookbookResponseJson()),
+    next = "next",
+    previous = "previous"
+)
+
+private fun createMockCookbookResponseJson() = CookbooksResponseJson(
+    id = "id",
+    name = "name",
+    description = "description",
+    slug = "slug",
+    position = 1,
+    public = false,
+    queryFilterString = "queryFilterString",
+    groupId = "groupId",
+    householdId = "householdId",
+)


### PR DESCRIPTION
This commit introduces the `HouseholdsApi` to the Mealie client, providing functionality for managing household information.

The initial implementation includes a `getCookbooks()` method to retrieve a paginated list of cookbooks. Corresponding data models and tests have also been added.

The `MealieClient` has been updated to include an instance of the new `HouseholdsApi`.