### PR TITLE
Add endpoint for creating cookbooks

### DIFF
--- a/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/households/HouseholdsApi.kt
+++ b/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/households/HouseholdsApi.kt
@@ -1,9 +1,13 @@
 package com.saintpatrck.mealie.client.api.households
 
 import com.saintpatrck.mealie.client.api.households.model.CookbooksResponseJson
+import com.saintpatrck.mealie.client.api.households.model.CreateCookbookRequestJson
 import com.saintpatrck.mealie.client.api.model.MealieResponse
 import com.saintpatrck.mealie.client.api.model.PagedResponseJson
+import de.jensklingenberg.ktorfit.http.Body
 import de.jensklingenberg.ktorfit.http.GET
+import de.jensklingenberg.ktorfit.http.Headers
+import de.jensklingenberg.ktorfit.http.POST
 
 /**
  * API for managing household information.
@@ -15,4 +19,13 @@ interface HouseholdsApi {
      */
     @GET("households/cookbooks")
     suspend fun getCookbooks(): MealieResponse<PagedResponseJson<CookbooksResponseJson>>
+
+    /**
+     * Create a new cookbook.
+     */
+    @Headers("Content-Type: application/json")
+    @POST("households/cookbooks")
+    suspend fun createCookbook(
+        @Body cookbook: CreateCookbookRequestJson,
+    ): MealieResponse<CookbooksResponseJson>
 }

--- a/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/households/model/CreateCookbookRequestJson.kt
+++ b/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/households/model/CreateCookbookRequestJson.kt
@@ -1,0 +1,21 @@
+package com.saintpatrck.mealie.client.api.households.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Models the request body for creating a new cookbook.
+ */
+@Serializable
+data class CreateCookbookRequestJson(
+    @SerialName("name")
+    val name: String,
+    @SerialName("description")
+    val description: String,
+    @SerialName("slug")
+    val slug: String,
+    @SerialName("position")
+    val position: Int,
+    @SerialName("public")
+    val public: Boolean,
+)

--- a/client/src/commonTest/kotlin/com/saintpatrck/mealie/client/api/households/HouseholdsApiTest.kt
+++ b/client/src/commonTest/kotlin/com/saintpatrck/mealie/client/api/households/HouseholdsApiTest.kt
@@ -2,8 +2,10 @@ package com.saintpatrck.mealie.client.api.households
 
 import com.saintpatrck.mealie.client.api.base.BaseApiTest
 import com.saintpatrck.mealie.client.api.households.model.CookbooksResponseJson
+import com.saintpatrck.mealie.client.api.households.model.CreateCookbookRequestJson
 import com.saintpatrck.mealie.client.api.model.PagedResponseJson
 import com.saintpatrck.mealie.client.api.model.getOrNull
+import com.saintpatrck.mealie.client.api.model.getOrThrow
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -19,6 +21,27 @@ class HouseholdsApiTest : BaseApiTest() {
                 assertEquals(
                     createMockPagedCookbooksResponseJson(),
                     response.getOrNull(),
+                )
+            }
+    }
+
+    @Test
+    fun `createCookbook should deserialize correctly`() = runTest {
+        createTestMealieClient(responseJson = CREATE_COOKBOOK_RESPONSE_JSON)
+            .householdsApi
+            .createCookbook(
+                cookbook = CreateCookbookRequestJson(
+                    name = "name",
+                    description = "description",
+                    slug = "slug",
+                    position = 1,
+                    public = false,
+                )
+            )
+            .also { response ->
+                assertEquals(
+                    createMockCookbookResponseJson(),
+                    response.getOrThrow(),
                 )
             }
     }
@@ -48,6 +71,23 @@ private val GET_COOKBOOKS_RESPONSE_JSON = """
   ],
   "next": "next",
   "previous": "previous"
+}
+"""
+    .trimIndent()
+private val CREATE_COOKBOOK_RESPONSE_JSON = """
+{
+  "name": "name",
+  "description": "description",
+  "slug": "slug",
+  "position": 1,
+  "public": false,
+  "queryFilterString": "queryFilterString",
+  "groupId": "groupId",
+  "householdId": "householdId",
+  "id": "id",
+  "queryFilter": {
+    "parts": []
+  }
 }
 """
     .trimIndent()


### PR DESCRIPTION
This commit introduces the functionality to create new cookbooks through the API.

It includes:
- A new `createCookbook` method in `HouseholdsApi`.
- The `CreateCookbookRequestJson` data class to model the request body.
- Unit tests for the new endpoint, verifying correct deserialization of the response.