### PR TITLE
Refactor Households API and add bulk update endpoint

### DIFF
--- a/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/households/HouseholdsApi.kt
+++ b/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/households/HouseholdsApi.kt
@@ -1,6 +1,6 @@
 package com.saintpatrck.mealie.client.api.households
 
-import com.saintpatrck.mealie.client.api.households.model.CookbooksResponseJson
+import com.saintpatrck.mealie.client.api.households.model.CookbookJson
 import com.saintpatrck.mealie.client.api.households.model.CreateCookbookRequestJson
 import com.saintpatrck.mealie.client.api.model.MealieResponse
 import com.saintpatrck.mealie.client.api.model.PagedResponseJson
@@ -8,6 +8,7 @@ import de.jensklingenberg.ktorfit.http.Body
 import de.jensklingenberg.ktorfit.http.GET
 import de.jensklingenberg.ktorfit.http.Headers
 import de.jensklingenberg.ktorfit.http.POST
+import de.jensklingenberg.ktorfit.http.PUT
 
 /**
  * API for managing household information.
@@ -18,7 +19,7 @@ interface HouseholdsApi {
      * Retrieves a list of cookbooks.
      */
     @GET("households/cookbooks")
-    suspend fun getCookbooks(): MealieResponse<PagedResponseJson<CookbooksResponseJson>>
+    suspend fun getCookbooks(): MealieResponse<PagedResponseJson<CookbookJson>>
 
     /**
      * Create a new cookbook.
@@ -27,5 +28,14 @@ interface HouseholdsApi {
     @POST("households/cookbooks")
     suspend fun createCookbook(
         @Body cookbook: CreateCookbookRequestJson,
-    ): MealieResponse<CookbooksResponseJson>
+    ): MealieResponse<CookbookJson>
+
+    /**
+     * Bulk update cookbooks.
+     */
+    @Headers("Content-Type: application/json")
+    @PUT("households/cookbooks")
+    suspend fun bulkUpdateCookbooks(
+        @Body bulkUpdateRequest: List<CookbookJson>,
+    ): MealieResponse<List<CookbookJson>>
 }

--- a/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/households/model/CookbookJson.kt
+++ b/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/households/model/CookbookJson.kt
@@ -7,7 +7,7 @@ import kotlinx.serialization.Serializable
  * Models a cookbook.
  */
 @Serializable
-data class CookbooksResponseJson(
+data class CookbookJson(
     @SerialName("name")
     val name: String,
     @SerialName("description")

--- a/client/src/commonTest/kotlin/com/saintpatrck/mealie/client/api/households/HouseholdsApiTest.kt
+++ b/client/src/commonTest/kotlin/com/saintpatrck/mealie/client/api/households/HouseholdsApiTest.kt
@@ -1,7 +1,7 @@
 package com.saintpatrck.mealie.client.api.households
 
 import com.saintpatrck.mealie.client.api.base.BaseApiTest
-import com.saintpatrck.mealie.client.api.households.model.CookbooksResponseJson
+import com.saintpatrck.mealie.client.api.households.model.CookbookJson
 import com.saintpatrck.mealie.client.api.households.model.CreateCookbookRequestJson
 import com.saintpatrck.mealie.client.api.model.PagedResponseJson
 import com.saintpatrck.mealie.client.api.model.getOrNull
@@ -27,7 +27,7 @@ class HouseholdsApiTest : BaseApiTest() {
 
     @Test
     fun `createCookbook should deserialize correctly`() = runTest {
-        createTestMealieClient(responseJson = CREATE_COOKBOOK_RESPONSE_JSON)
+        createTestMealieClient(responseJson = COOKBOOK_JSON)
             .householdsApi
             .createCookbook(
                 cookbook = CreateCookbookRequestJson(
@@ -40,11 +40,27 @@ class HouseholdsApiTest : BaseApiTest() {
             )
             .also { response ->
                 assertEquals(
-                    createMockCookbookResponseJson(),
+                    createMockCookbookJson(),
                     response.getOrThrow(),
                 )
             }
     }
+
+    @Test
+    fun `bulkUpdateCookbooks should deserialize correctly`() = runTest {
+        createTestMealieClient(responseJson = BULK_UPDATE_RESPONSE_JSON)
+            .householdsApi
+            .bulkUpdateCookbooks(
+                bulkUpdateRequest = listOf(createMockCookbookJson())
+            )
+            .also { response ->
+                assertEquals(
+                    listOf(createMockCookbookJson()),
+                    response.getOrThrow(),
+                )
+            }
+    }
+
 }
 
 private val GET_COOKBOOKS_RESPONSE_JSON = """
@@ -74,7 +90,7 @@ private val GET_COOKBOOKS_RESPONSE_JSON = """
 }
 """
     .trimIndent()
-private val CREATE_COOKBOOK_RESPONSE_JSON = """
+private val COOKBOOK_JSON = """
 {
   "name": "name",
   "description": "description",
@@ -91,17 +107,35 @@ private val CREATE_COOKBOOK_RESPONSE_JSON = """
 }
 """
     .trimIndent()
+private val BULK_UPDATE_RESPONSE_JSON = """
+[
+  {
+    "name": "name",
+    "description": "description",
+    "slug": "slug",
+    "position": 1,
+    "public": false,
+    "queryFilterString": "queryFilterString",
+    "groupId": "groupId",
+    "householdId": "householdId",
+    "id": "id",
+    "queryFilter": {
+      "parts": []
+    }
+  }
+]
+""".trimIndent()
 
 private fun createMockPagedCookbooksResponseJson() = PagedResponseJson(
     page = 1,
     perPage = 10,
     totalPages = 0,
-    items = listOf(createMockCookbookResponseJson()),
+    items = listOf(createMockCookbookJson()),
     next = "next",
     previous = "previous"
 )
 
-private fun createMockCookbookResponseJson() = CookbooksResponseJson(
+private fun createMockCookbookJson() = CookbookJson(
     id = "id",
     name = "name",
     description = "description",


### PR DESCRIPTION
This commit refactors the `HouseholdsApi` by renaming `CookbooksResponseJson` to `CookbookJson` for better clarity and consistency.

Additionally, a new endpoint `bulkUpdateCookbooks` has been added to allow for bulk updating of cookbooks. Corresponding tests for this new functionality have also been included.