### PR TITLE
Add get cookbook endpoint and `CookbookWithRecipesJson` model

### DIFF
--- a/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/households/HouseholdsApi.kt
+++ b/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/households/HouseholdsApi.kt
@@ -1,6 +1,7 @@
 package com.saintpatrck.mealie.client.api.households
 
 import com.saintpatrck.mealie.client.api.households.model.CookbookJson
+import com.saintpatrck.mealie.client.api.households.model.CookbookWithRecipesJson
 import com.saintpatrck.mealie.client.api.households.model.CreateCookbookRequestJson
 import com.saintpatrck.mealie.client.api.model.MealieResponse
 import com.saintpatrck.mealie.client.api.model.PagedResponseJson
@@ -9,6 +10,7 @@ import de.jensklingenberg.ktorfit.http.GET
 import de.jensklingenberg.ktorfit.http.Headers
 import de.jensklingenberg.ktorfit.http.POST
 import de.jensklingenberg.ktorfit.http.PUT
+import de.jensklingenberg.ktorfit.http.Path
 
 /**
  * API for managing household information.
@@ -38,4 +40,13 @@ interface HouseholdsApi {
     suspend fun bulkUpdateCookbooks(
         @Body bulkUpdateRequest: List<CookbookJson>,
     ): MealieResponse<List<CookbookJson>>
+
+    /**
+     * Retrieves a cookbook by its ID.
+     */
+    @GET("households/cookbooks/{cookbookId}")
+    suspend fun getCookbook(
+        @Path("cookbookId")
+        cookbookId: String,
+    ): MealieResponse<CookbookWithRecipesJson>
 }

--- a/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/households/model/CookbookWithRecipesJson.kt
+++ b/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/households/model/CookbookWithRecipesJson.kt
@@ -1,0 +1,180 @@
+package com.saintpatrck.mealie.client.api.households.model
+
+import kotlinx.datetime.Instant
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Models a cookbook with its associated recipes.
+ *
+ * @property id The ID of the cookbook.
+ * @property name The name of the cookbook.
+ * @property description The description of the cookbook.
+ * @property slug The slug associated with the cookbook.
+ * @property position The ordinal position of the cookbook when displayed in a list.
+ * @property public Whether the cookbook is public.
+ * @property queryFilterString The query filter string associated with the cookbook.
+ * @property groupId The ID of the group that the cookbook belongs to.
+ * @property householdId The ID of the household that the cookbook belongs to.
+ * @property recipes The list of recipes in the cookbook.
+ */
+@Serializable
+data class CookbookWithRecipesJson(
+    @SerialName("id")
+    val id: String,
+    @SerialName("name")
+    val name: String,
+    @SerialName("description")
+    val description: String,
+    @SerialName("slug")
+    val slug: String,
+    @SerialName("position")
+    val position: Int,
+    @SerialName("public")
+    val public: Boolean,
+    @SerialName("queryFilterString")
+    val queryFilterString: String,
+    @SerialName("groupId")
+    val groupId: String,
+    @SerialName("householdId")
+    val householdId: String,
+    @SerialName("recipes")
+    val recipes: List<RecipeJson>,
+) {
+    /**
+     * Models a recipe in a cookbook.
+     *
+     * @property id The ID of the recipe.
+     * @property userId The ID of the user who added the recipe.
+     * @property householdId The ID of the household that the recipe belongs to.
+     * @property groupId The ID of the group that the recipe belongs to.
+     * @property name The name of the recipe.
+     * @property slug The slug associated with the recipe.
+     * @property image The image associated with the recipe.
+     * @property recipeServings The number of servings in the recipe.
+     * @property recipeYieldQuantity The quantity of the recipe yield.
+     * @property recipeYield The yield of the recipe.
+     * @property totalTime The total time it takes to make the recipe.
+     * @property prepTime The preparation time of the recipe.
+     * @property cookTime The cooking time of the recipe.
+     * @property performTime The active time required for the recipe.
+     * @property description The description of the recipe.
+     * @property recipeCategory The categories the recipe belongs to.
+     * @property tags The tags associated with the recipe.
+     * @property tools The tools required to make the recipe.
+     * @property rating The overall rating of the recipe.
+     * @property orgUrl The original URL associated with the recipe.
+     * @property dateAdded The date when the recipe was added.
+     * @property dateUpdated The date when the recipe was last updated.
+     * @property createdAt The creation date of the recipe.
+     * @property updatedAt The last update date of the recipe.
+     * @property lastMade The date when the recipe was last made.
+     */
+    @Serializable
+    data class RecipeJson(
+        @SerialName("id")
+        val id: String,
+        @SerialName("userId")
+        val userId: String,
+        @SerialName("householdId")
+        val householdId: String,
+        @SerialName("groupId")
+        val groupId: String,
+        @SerialName("name")
+        val name: String?,
+        @SerialName("slug")
+        val slug: String,
+        @SerialName("image")
+        val image: ByteArray?,
+        @SerialName("recipeServings")
+        val recipeServings: Double,
+        @SerialName("recipeYieldQuantity")
+        val recipeYieldQuantity: Double,
+        @SerialName("recipeYield")
+        val recipeYield: String?,
+        @SerialName("totalTime")
+        val totalTime: String?,
+        @SerialName("prepTime")
+        val prepTime: String?,
+        @SerialName("cookTime")
+        val cookTime: String?,
+        @SerialName("performTime")
+        val performTime: String?,
+        @SerialName("description")
+        val description: String,
+        @SerialName("recipeCategory")
+        val recipeCategory: List<RecipeCategory>,
+        @SerialName("tags")
+        val tags: List<RecipeTag>,
+        @SerialName("tools")
+        val tools: List<RecipeTool>,
+        @SerialName("rating")
+        val rating: Double?,
+        @SerialName("orgURL")
+        val orgUrl: String?,
+        @SerialName("dateAdded")
+        val dateAdded: String,
+        @SerialName("dateUpdated")
+        val dateUpdated: Instant,
+        @SerialName("createdAt")
+        val createdAt: Instant,
+        @SerialName("updatedAt")
+        val updatedAt: Instant,
+        @SerialName("lastMade")
+        val lastMade: Instant,
+    ) {
+        /**
+         * Models a recipe category.
+         *
+         * @property id The ID of the recipe category.
+         * @property name The name of the recipe category.
+         * @property slug The slug associated with the recipe category.
+         */
+        @Serializable
+        data class RecipeCategory(
+            @SerialName("id")
+            val id: String,
+            @SerialName("name")
+            val name: String,
+            @SerialName("slug")
+            val slug: String,
+        )
+
+        /**
+         * Models a recipe tag.
+         *
+         * @property id The ID of the recipe tag.
+         * @property name The name of the recipe tag.
+         * @property slug The slug associated with the recipe tag.
+         */
+        @Serializable
+        data class RecipeTag(
+            @SerialName("id")
+            val id: String,
+            @SerialName("name")
+            val name: String,
+            @SerialName("slug")
+            val slug: String,
+        )
+
+        /**
+         * Models a recipe tool.
+         *
+         * @property id The ID of the recipe tool.
+         * @property name The name of the recipe tool.
+         * @property slug The slug associated with the recipe tool.
+         * @property householdsWithTool The list of households that have the tool.
+         */
+        @Serializable
+        data class RecipeTool(
+            @SerialName("id")
+            val id: String,
+            @SerialName("name")
+            val name: String,
+            @SerialName("slug")
+            val slug: String,
+            @SerialName("householdsWithTool")
+            val householdsWithTool: List<String>,
+        )
+    }
+}

--- a/client/src/commonTest/kotlin/com/saintpatrck/mealie/client/api/households/HouseholdsApiTest.kt
+++ b/client/src/commonTest/kotlin/com/saintpatrck/mealie/client/api/households/HouseholdsApiTest.kt
@@ -2,11 +2,13 @@ package com.saintpatrck.mealie.client.api.households
 
 import com.saintpatrck.mealie.client.api.base.BaseApiTest
 import com.saintpatrck.mealie.client.api.households.model.CookbookJson
+import com.saintpatrck.mealie.client.api.households.model.CookbookWithRecipesJson
 import com.saintpatrck.mealie.client.api.households.model.CreateCookbookRequestJson
 import com.saintpatrck.mealie.client.api.model.PagedResponseJson
 import com.saintpatrck.mealie.client.api.model.getOrNull
 import com.saintpatrck.mealie.client.api.model.getOrThrow
 import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.Instant
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -61,6 +63,20 @@ class HouseholdsApiTest : BaseApiTest() {
             }
     }
 
+    @Test
+    fun `getCookbook should deserialize correctly`() = runTest {
+        createTestMealieClient(responseJson = COOKBOOK_WITH_RECIPES_JSON)
+            .householdsApi
+            .getCookbook(
+                cookbookId = "cookbookId"
+            )
+            .also { response ->
+                assertEquals(
+                    createMockCookbookWithRecipesJson(),
+                    response.getOrThrow(),
+                )
+            }
+    }
 }
 
 private val GET_COOKBOOKS_RESPONSE_JSON = """
@@ -124,7 +140,75 @@ private val BULK_UPDATE_RESPONSE_JSON = """
     }
   }
 ]
-""".trimIndent()
+"""
+    .trimIndent()
+private val COOKBOOK_WITH_RECIPES_JSON = """
+{
+  "name": "name",
+  "description": "description",
+  "slug": "slug",
+  "position": 1,
+  "public": false,
+  "queryFilterString": "queryFilterString",
+  "groupId": "groupId",
+  "householdId": "householdId",
+  "id": "id",
+  "queryFilter": {
+    "parts": []
+  },
+  "recipes": [
+    {
+      "id": "id",
+      "userId": "userId",
+      "householdId": "householdId",
+      "groupId": "groupId",
+      "name": "name",
+      "slug": "slug",
+      "image": null,
+      "recipeServings": 0,
+      "recipeYieldQuantity": 0,
+      "recipeYield": "recipeYield",
+      "totalTime": "totalTime",
+      "prepTime": "prepTime",
+      "cookTime": "cookTime",
+      "performTime": "performTime",
+      "description": "description",
+      "recipeCategory": [
+        {
+          "id": "id",
+          "name": "name",
+          "slug": "slug"
+        }
+      ],
+      "tags": [
+        {
+          "id": "id",
+          "name": "name",
+          "slug": "slug"
+        }
+      ],
+      "tools": [
+        {
+          "id": "id",
+          "name": "name",
+          "slug": "slug",
+          "householdsWithTool": [
+            "householdsWithTool"
+          ]
+        }
+      ],
+      "rating": 0.0,
+      "orgURL": "orgURL",
+      "dateAdded": "2019-08-24",
+      "dateUpdated": "2019-08-24T14:15:22Z",
+      "createdAt": "2019-08-24T14:15:22Z",
+      "updatedAt": "2019-08-24T14:15:22Z",
+      "lastMade": "2019-08-24T14:15:22Z"
+    }
+  ]
+}
+"""
+    .trimIndent()
 
 private fun createMockPagedCookbooksResponseJson() = PagedResponseJson(
     page = 1,
@@ -145,4 +229,64 @@ private fun createMockCookbookJson() = CookbookJson(
     queryFilterString = "queryFilterString",
     groupId = "groupId",
     householdId = "householdId",
+)
+
+private fun createMockCookbookWithRecipesJson() = CookbookWithRecipesJson(
+    id = "id",
+    name = "name",
+    description = "description",
+    slug = "slug",
+    position = 1,
+    public = false,
+    queryFilterString = "queryFilterString",
+    groupId = "groupId",
+    householdId = "householdId",
+    recipes = listOf(createMockRecipeJson())
+)
+
+private fun createMockRecipeJson() = CookbookWithRecipesJson.RecipeJson(
+    id = "id",
+    userId = "userId",
+    householdId = "householdId",
+    groupId = "groupId",
+    name = "name",
+    slug = "slug",
+    image = null,
+    recipeServings = 0.0,
+    recipeYieldQuantity = 0.0,
+    recipeYield = "recipeYield",
+    totalTime = "totalTime",
+    prepTime = "prepTime",
+    cookTime = "cookTime",
+    performTime = "performTime",
+    description = "description",
+    recipeCategory = listOf(createMockRecipeCategory()),
+    tags = listOf(createMockRecipeTag()),
+    tools = listOf(createMockRecipeTool()),
+    rating = 0.0,
+    orgUrl = "orgURL",
+    dateAdded = "2019-08-24",
+    dateUpdated = Instant.parse("2019-08-24T14:15:22Z"),
+    createdAt = Instant.parse("2019-08-24T14:15:22Z"),
+    updatedAt = Instant.parse("2019-08-24T14:15:22Z"),
+    lastMade = Instant.parse("2019-08-24T14:15:22Z"),
+)
+
+private fun createMockRecipeCategory() = CookbookWithRecipesJson.RecipeJson.RecipeCategory(
+    id = "id",
+    name = "name",
+    slug = "slug",
+)
+
+private fun createMockRecipeTag() = CookbookWithRecipesJson.RecipeJson.RecipeTag(
+    id = "id",
+    name = "name",
+    slug = "slug",
+)
+
+private fun createMockRecipeTool() = CookbookWithRecipesJson.RecipeJson.RecipeTool(
+    id = "id",
+    name = "name",
+    slug = "slug",
+    householdsWithTool = listOf("householdsWithTool")
 )


### PR DESCRIPTION
This commit introduces a new endpoint to the `HouseholdsApi` for retrieving a specific cookbook by its ID. It also adds the corresponding `CookbookWithRecipesJson` data class to model the response, which includes the cookbook's details and a list of its associated recipes.