### PR TITLE
Add `updateCookbook` endpoint and tests

### DIFF
--- a/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/households/HouseholdsApi.kt
+++ b/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/households/HouseholdsApi.kt
@@ -3,6 +3,7 @@ package com.saintpatrck.mealie.client.api.households
 import com.saintpatrck.mealie.client.api.households.model.CookbookJson
 import com.saintpatrck.mealie.client.api.households.model.CookbookWithRecipesJson
 import com.saintpatrck.mealie.client.api.households.model.CreateCookbookRequestJson
+import com.saintpatrck.mealie.client.api.households.model.UpdateCookbookRequestJson
 import com.saintpatrck.mealie.client.api.model.MealieResponse
 import com.saintpatrck.mealie.client.api.model.PagedResponseJson
 import de.jensklingenberg.ktorfit.http.Body
@@ -49,4 +50,15 @@ interface HouseholdsApi {
         @Path("cookbookId")
         cookbookId: String,
     ): MealieResponse<CookbookWithRecipesJson>
+
+    /**
+     * Update a cookbook.
+     */
+    @Headers("Content-Type: application/json")
+    @PUT("households/cookbooks/{cookbookId}")
+    suspend fun updateCookbook(
+        @Path("cookbookId")
+        cookbookId: String,
+        @Body cookbook: UpdateCookbookRequestJson,
+    ): MealieResponse<CookbookJson>
 }

--- a/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/households/model/CookbookJson.kt
+++ b/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/households/model/CookbookJson.kt
@@ -13,7 +13,7 @@ data class CookbookJson(
     @SerialName("description")
     val description: String,
     @SerialName("slug")
-    val slug: String,
+    val slug: String?,
     @SerialName("position")
     val position: Int,
     @SerialName("public")

--- a/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/households/model/UpdateCookbookRequestJson.kt
+++ b/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/households/model/UpdateCookbookRequestJson.kt
@@ -1,0 +1,30 @@
+package com.saintpatrck.mealie.client.api.households.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Models a request to update a cookbook.
+ *
+ * @property name The name of the cookbook.
+ * @property description The description of the cookbook.
+ * @property slug The slug associated with the cookbook.
+ * @property position The ordinal position of the cookbook when displayed in a list.
+ * @property public Whether the cookbook is public.
+ * @property queryFilterString The query filter string associated with the cookbook.
+ */
+@Serializable
+data class UpdateCookbookRequestJson(
+    @SerialName("name")
+    val name: String,
+    @SerialName("description")
+    val description: String,
+    @SerialName("slug")
+    val slug: String?,
+    @SerialName("position")
+    val position: Int,
+    @SerialName("public")
+    val public: Boolean,
+    @SerialName("queryFilterString")
+    val queryFilterString: String?,
+)

--- a/client/src/commonTest/kotlin/com/saintpatrck/mealie/client/api/households/HouseholdsApiTest.kt
+++ b/client/src/commonTest/kotlin/com/saintpatrck/mealie/client/api/households/HouseholdsApiTest.kt
@@ -4,6 +4,7 @@ import com.saintpatrck.mealie.client.api.base.BaseApiTest
 import com.saintpatrck.mealie.client.api.households.model.CookbookJson
 import com.saintpatrck.mealie.client.api.households.model.CookbookWithRecipesJson
 import com.saintpatrck.mealie.client.api.households.model.CreateCookbookRequestJson
+import com.saintpatrck.mealie.client.api.households.model.UpdateCookbookRequestJson
 import com.saintpatrck.mealie.client.api.model.PagedResponseJson
 import com.saintpatrck.mealie.client.api.model.getOrNull
 import com.saintpatrck.mealie.client.api.model.getOrThrow
@@ -73,6 +74,29 @@ class HouseholdsApiTest : BaseApiTest() {
             .also { response ->
                 assertEquals(
                     createMockCookbookWithRecipesJson(),
+                    response.getOrThrow(),
+                )
+            }
+    }
+
+    @Test
+    fun `updateCookbook should deserialize correctly`() = runTest {
+        createTestMealieClient(responseJson = COOKBOOK_JSON)
+            .householdsApi
+            .updateCookbook(
+                cookbookId = "cookbookId",
+                cookbook = UpdateCookbookRequestJson(
+                    name = "name",
+                    description = "description",
+                    slug = "slug",
+                    position = 1,
+                    public = false,
+                    queryFilterString = "queryFilterString",
+                )
+            )
+            .also { response ->
+                assertEquals(
+                    createMockCookbookJson(),
                     response.getOrThrow(),
                 )
             }


### PR DESCRIPTION
This commit introduces the `updateCookbook` endpoint to the `HouseholdsApi`.

It includes:
- `UpdateCookbookRequestJson` data class for the request body.
- The `updateCookbook` function in `HouseholdsApi`.
- A corresponding test case `updateCookbook should deserialize correctly` in `HouseholdsApiTest`.
- The `slug` property in `CookbookJson` is now nullable to reflect API behavior.