### PR TITLE
Add HouseholdsApi.deleteCookbook

### DIFF
--- a/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/households/HouseholdsApi.kt
+++ b/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/households/HouseholdsApi.kt
@@ -7,6 +7,7 @@ import com.saintpatrck.mealie.client.api.households.model.UpdateCookbookRequestJ
 import com.saintpatrck.mealie.client.api.model.MealieResponse
 import com.saintpatrck.mealie.client.api.model.PagedResponseJson
 import de.jensklingenberg.ktorfit.http.Body
+import de.jensklingenberg.ktorfit.http.DELETE
 import de.jensklingenberg.ktorfit.http.GET
 import de.jensklingenberg.ktorfit.http.Headers
 import de.jensklingenberg.ktorfit.http.POST
@@ -60,5 +61,14 @@ interface HouseholdsApi {
         @Path("cookbookId")
         cookbookId: String,
         @Body cookbook: UpdateCookbookRequestJson,
+    ): MealieResponse<CookbookJson>
+
+    /**
+     * Delete a cookbook.
+     */
+    @DELETE("households/cookbooks/{cookbookId}")
+    suspend fun deleteCookbook(
+        @Path("cookbookId")
+        cookbookId: String,
     ): MealieResponse<CookbookJson>
 }

--- a/client/src/commonTest/kotlin/com/saintpatrck/mealie/client/api/households/HouseholdsApiTest.kt
+++ b/client/src/commonTest/kotlin/com/saintpatrck/mealie/client/api/households/HouseholdsApiTest.kt
@@ -101,6 +101,21 @@ class HouseholdsApiTest : BaseApiTest() {
                 )
             }
     }
+
+    @Test
+    fun `deleteCookbook should deserialize correctly`() = runTest {
+        createTestMealieClient(responseJson = COOKBOOK_JSON)
+            .householdsApi
+            .deleteCookbook(
+                cookbookId = "cookbookId"
+            )
+            .also { response ->
+                assertEquals(
+                    createMockCookbookJson(),
+                    response.getOrThrow(),
+                )
+            }
+    }
 }
 
 private val GET_COOKBOOKS_RESPONSE_JSON = """


### PR DESCRIPTION
This commit introduces the `deleteCookbook` function to the `HouseholdsApi` interface, allowing for the deletion of cookbooks. Corresponding tests have been added to ensure correct deserialization of the response.