### PR TITLE
Allow request verification in MockEngine setup

### DIFF
--- a/client/src/commonTest/kotlin/com/saintpatrck/mealie/client/api/base/BaseApiTest.kt
+++ b/client/src/commonTest/kotlin/com/saintpatrck/mealie/client/api/base/BaseApiTest.kt
@@ -7,6 +7,7 @@ import com.saintpatrck.mealie.client.provider.MealieTokenProvider
 import createMockEngine
 import io.ktor.client.plugins.logging.LogLevel
 import io.ktor.client.plugins.logging.Logger
+import io.ktor.client.request.HttpRequestData
 import io.ktor.http.Headers
 import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
@@ -41,11 +42,13 @@ abstract class BaseApiTest {
         responseJson: String,
         status: HttpStatusCode = HttpStatusCode.OK,
         headers: Headers = headersOf(HttpHeaders.ContentType, "application/json"),
+        verifyRequest: suspend (request: HttpRequestData) -> Unit = {},
     ) = mealieClient {
         engine = createMockEngine(
             response = responseJson,
             status = status,
             headers = headers,
+            verifyRequest = verifyRequest,
         )
         baseUrlProvider = urlProvider
         accessTokenProvider = {

--- a/client/src/commonTest/kotlin/com/saintpatrck/mealie/client/api/households/HouseholdsApiTest.kt
+++ b/client/src/commonTest/kotlin/com/saintpatrck/mealie/client/api/households/HouseholdsApiTest.kt
@@ -8,6 +8,8 @@ import com.saintpatrck.mealie.client.api.households.model.UpdateCookbookRequestJ
 import com.saintpatrck.mealie.client.api.model.PagedResponseJson
 import com.saintpatrck.mealie.client.api.model.getOrNull
 import com.saintpatrck.mealie.client.api.model.getOrThrow
+import io.ktor.client.engine.mock.toByteArray
+import io.ktor.http.HttpMethod
 import kotlinx.coroutines.test.runTest
 import kotlinx.datetime.Instant
 import kotlin.test.Test
@@ -65,8 +67,14 @@ class HouseholdsApiTest : BaseApiTest() {
     }
 
     @Test
-    fun `getCookbook should deserialize correctly`() = runTest {
-        createTestMealieClient(responseJson = COOKBOOK_WITH_RECIPES_JSON)
+    fun `getCookbook should construct request and deserialize response correctly`() = runTest {
+        createTestMealieClient(
+            responseJson = COOKBOOK_WITH_RECIPES_JSON,
+            verifyRequest = { request ->
+                assertEquals(request.method, HttpMethod.Get)
+                assertEquals("/households/cookbooks/cookbookId", request.url.encodedPath)
+            }
+        )
             .householdsApi
             .getCookbook(
                 cookbookId = "cookbookId"
@@ -80,8 +88,18 @@ class HouseholdsApiTest : BaseApiTest() {
     }
 
     @Test
-    fun `updateCookbook should deserialize correctly`() = runTest {
-        createTestMealieClient(responseJson = COOKBOOK_JSON)
+    fun `updateCookbook should construct request and deserialize response correctly`() = runTest {
+        createTestMealieClient(
+            responseJson = COOKBOOK_JSON,
+            verifyRequest = { request ->
+                assertEquals(request.method, HttpMethod.Put)
+                assertEquals("/households/cookbooks/cookbookId", request.url.encodedPath)
+                assertEquals(
+                    UPDATE_COOKBOOK_REQUEST_JSON,
+                    request.body.toByteArray().decodeToString()
+                )
+            }
+        )
             .householdsApi
             .updateCookbook(
                 cookbookId = "cookbookId",
@@ -103,6 +121,10 @@ class HouseholdsApiTest : BaseApiTest() {
     }
 }
 
+private val UPDATE_COOKBOOK_REQUEST_JSON = """
+{"name":"name","description":"description","slug":"slug","position":1,"public":false,"queryFilterString":"queryFilterString"}
+"""
+    .trimIndent()
 private val GET_COOKBOOKS_RESPONSE_JSON = """
 {
   "page": 1,

--- a/client/src/commonTest/kotlin/com/saintpatrck/mealie/client/infrastructure/util/HttpClientEngineUtils.kt
+++ b/client/src/commonTest/kotlin/com/saintpatrck/mealie/client/infrastructure/util/HttpClientEngineUtils.kt
@@ -1,5 +1,6 @@
 import io.ktor.client.engine.mock.MockEngine
 import io.ktor.client.engine.mock.respond
+import io.ktor.client.request.HttpRequestData
 import io.ktor.http.Headers
 import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
@@ -12,8 +13,10 @@ fun createMockEngine(
     response: String,
     status: HttpStatusCode = HttpStatusCode.OK,
     headers: Headers = headersOf(HttpHeaders.ContentType, "application/json"),
+    verifyRequest: suspend (request: HttpRequestData) -> Unit = {},
 ): MockEngine {
     return MockEngine { request ->
+        verifyRequest(request)
         respond(
             content = response,
             status = status,


### PR DESCRIPTION
This commit introduces the ability to verify the request data within the `createMockEngine` utility function and its usage in `BaseApiTest`.

The `createMockEngine` function now accepts an optional `verifyRequest` lambda, which is executed with the `HttpRequestData` before the mock response is returned. This allows tests to assert specific details about the outgoing request.

The `BaseApiTest` has been updated to pass an empty lambda by default for `verifyRequest` in its `provideMealieClient` method.