### PR TITLE
Add support for retrieving event notifications

### DIFF
--- a/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/households/HouseholdsApi.kt
+++ b/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/households/HouseholdsApi.kt
@@ -3,8 +3,11 @@ package com.saintpatrck.mealie.client.api.households
 import com.saintpatrck.mealie.client.api.households.model.CookbookJson
 import com.saintpatrck.mealie.client.api.households.model.CookbookWithRecipesJson
 import com.saintpatrck.mealie.client.api.households.model.CreateCookbookRequestJson
+import com.saintpatrck.mealie.client.api.households.model.EventNotificationJson
 import com.saintpatrck.mealie.client.api.households.model.UpdateCookbookRequestJson
 import com.saintpatrck.mealie.client.api.model.MealieResponse
+import com.saintpatrck.mealie.client.api.model.OrderByNullPosition
+import com.saintpatrck.mealie.client.api.model.OrderDirection
 import com.saintpatrck.mealie.client.api.model.PagedResponseJson
 import de.jensklingenberg.ktorfit.http.Body
 import de.jensklingenberg.ktorfit.http.DELETE
@@ -13,6 +16,7 @@ import de.jensklingenberg.ktorfit.http.Headers
 import de.jensklingenberg.ktorfit.http.POST
 import de.jensklingenberg.ktorfit.http.PUT
 import de.jensklingenberg.ktorfit.http.Path
+import de.jensklingenberg.ktorfit.http.Query
 
 /**
  * API for managing household information.
@@ -71,4 +75,33 @@ interface HouseholdsApi {
         @Path("cookbookId")
         cookbookId: String,
     ): MealieResponse<CookbookJson>
+
+    /**
+     * Retrieves all event notifications.
+     *
+     * @param orderBy The field to order the results by
+     * @param orderByNullPosition The position to order null values
+     * @param orderDirection The direction to order the results
+     * @param queryFilter A filter to apply to the results
+     * @param paginationSeed A seed to use for pagination
+     * @param page The page number to retrieve. Defaults to 1.
+     * @param perPage The number of items to retrieve per page. Defaults to 50.
+     */
+    @GET("households/events/notifications")
+    suspend fun getNotifications(
+        @Query("orderBy")
+        orderBy: String? = null,
+        @Query("orderByNullPosition")
+        orderByNullPosition: OrderByNullPosition? = null,
+        @Query("orderDirection")
+        orderDirection: OrderDirection? = null,
+        @Query("queryFilter")
+        queryFilter: String? = null,
+        @Query("paginationSeed")
+        paginationSeed: Int? = null,
+        @Query("page")
+        page: Int = 1,
+        @Query("perPage")
+        perPage: Int = 50,
+    ): MealieResponse<PagedResponseJson<EventNotificationJson>>
 }

--- a/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/households/model/EventNotificationJson.kt
+++ b/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/households/model/EventNotificationJson.kt
@@ -1,0 +1,85 @@
+package com.saintpatrck.mealie.client.api.households.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Models a general event notification.
+ *
+ * @param id The ID of the event notification
+ * @param name The name of the event notification
+ * @param enabled Whether the event notification is enabled
+ * @param groupId The ID of the group the event notification belongs to
+ * @param householdId The ID of the household the event notification belongs to
+ * @param options A list of options for the event notification
+ */
+@Serializable
+data class EventNotificationJson(
+    @SerialName("id")
+    val id: String,
+    @SerialName("name")
+    val name: String,
+    @SerialName("enabled")
+    val enabled: Boolean,
+    @SerialName("groupId")
+    val groupId: String,
+    @SerialName("householdId")
+    val householdId: String,
+    @SerialName("options")
+    val options: List<EventNotificationOptionJson>,
+) {
+    /**
+     * Options Model
+     *
+     * Describes an individual options entry
+     */
+    @Serializable
+    data class EventNotificationOptionJson(
+        @SerialName("testMessage")
+        val testMessage: Boolean,
+        @SerialName("webhookTask")
+        val webhookTask: Boolean,
+        @SerialName("recipeCreated")
+        val recipeCreated: Boolean,
+        @SerialName("recipeUpdated")
+        val recipeUpdated: Boolean,
+        @SerialName("recipeDeleted")
+        val recipeDeleted: Boolean,
+        @SerialName("userSignup")
+        val userSignup: Boolean,
+        @SerialName("dataMigrations")
+        val dataMigrations: Boolean,
+        @SerialName("dataExport")
+        val dataExport: Boolean,
+        @SerialName("dataImport")
+        val dataImport: Boolean,
+        @SerialName("mealplanEntryCreated")
+        val mealplanEntryCreated: Boolean,
+        @SerialName("shoppingListCreated")
+        val shoppingListCreated: Boolean,
+        @SerialName("shoppingListUpdated")
+        val shoppingListUpdated: Boolean,
+        @SerialName("shoppingListDeleted")
+        val shoppingListDeleted: Boolean,
+        @SerialName("cookbookCreated")
+        val cookbookCreated: Boolean,
+        @SerialName("cookbookUpdated")
+        val cookbookUpdated: Boolean,
+        @SerialName("cookbookDeleted")
+        val cookbookDeleted: Boolean,
+        @SerialName("tagCreated")
+        val tagCreated: Boolean,
+        @SerialName("tagUpdated")
+        val tagUpdated: Boolean,
+        @SerialName("tagDeleted")
+        val tagDeleted: Boolean,
+        @SerialName("categoryCreated")
+        val categoryCreated: Boolean,
+        @SerialName("categoryUpdated")
+        val categoryUpdated: Boolean,
+        @SerialName("categoryDeleted")
+        val categoryDeleted: Boolean,
+        @SerialName("id")
+        val id: String,
+    )
+}

--- a/client/src/commonTest/kotlin/com/saintpatrck/mealie/client/api/households/HouseholdsApiTest.kt
+++ b/client/src/commonTest/kotlin/com/saintpatrck/mealie/client/api/households/HouseholdsApiTest.kt
@@ -4,6 +4,7 @@ import com.saintpatrck.mealie.client.api.base.BaseApiTest
 import com.saintpatrck.mealie.client.api.households.model.CookbookJson
 import com.saintpatrck.mealie.client.api.households.model.CookbookWithRecipesJson
 import com.saintpatrck.mealie.client.api.households.model.CreateCookbookRequestJson
+import com.saintpatrck.mealie.client.api.households.model.EventNotificationJson
 import com.saintpatrck.mealie.client.api.households.model.UpdateCookbookRequestJson
 import com.saintpatrck.mealie.client.api.model.PagedResponseJson
 import com.saintpatrck.mealie.client.api.model.getOrNull
@@ -134,8 +135,79 @@ class HouseholdsApiTest : BaseApiTest() {
                 )
             }
     }
+
+    @Test
+    fun `getNotifications should deserialize correctly`() = runTest {
+        createTestMealieClient(
+            verifyRequest = { request ->
+                assertEquals(HttpMethod.Get, request.method)
+                assertEquals("/households/events/notifications", request.url.encodedPath)
+                assertEquals("1", request.url.parameters["page"])
+                assertEquals("10", request.url.parameters["perPage"])
+            },
+            responseJson = PAGED_EVENT_NOTIFICATIONS_RESPONSE_JSON,
+        )
+            .householdsApi
+            .getNotifications(
+                page = 1,
+                perPage = 10,
+            )
+            .also { response ->
+                assertEquals(
+                    createMockPagedEventNotificationsResponse(),
+                    response.getOrThrow(),
+                )
+            }
+    }
 }
 
+private val PAGED_EVENT_NOTIFICATIONS_RESPONSE_JSON = """
+{
+  "page": 1,
+  "per_page": 10,
+  "total": 0,
+  "total_pages": 0,
+  "items": [
+    {
+      "id": "id",
+      "name": "name",
+      "enabled": true,
+      "groupId": "groupId",
+      "householdId": "householdId",
+      "options": [
+        {
+          "testMessage": false,
+          "webhookTask": false,
+          "recipeCreated": false,
+          "recipeUpdated": false,
+          "recipeDeleted": false,
+          "userSignup": false,
+          "dataMigrations": false,
+          "dataExport": false,
+          "dataImport": false,
+          "mealplanEntryCreated": false,
+          "shoppingListCreated": false,
+          "shoppingListUpdated": false,
+          "shoppingListDeleted": false,
+          "cookbookCreated": false,
+          "cookbookUpdated": false,
+          "cookbookDeleted": false,
+          "tagCreated": false,
+          "tagUpdated": false,
+          "tagDeleted": false,
+          "categoryCreated": false,
+          "categoryUpdated": false,
+          "categoryDeleted": false,
+          "id": "id"
+        }
+      ]
+    }
+  ],
+  "next": "next",
+  "previous": "previous"
+}
+"""
+    .trimIndent()
 private val UPDATE_COOKBOOK_REQUEST_JSON = """
 {"name":"name","description":"description","slug":"slug","position":1,"public":false,"queryFilterString":"queryFilterString"}
 """
@@ -270,6 +342,51 @@ private val COOKBOOK_WITH_RECIPES_JSON = """
 }
 """
     .trimIndent()
+
+private fun createMockPagedEventNotificationsResponse() = PagedResponseJson(
+    page = 1,
+    perPage = 10,
+    totalPages = 0,
+    items = listOf(createMockEventNotificationJson()),
+    next = "next",
+    previous = "previous",
+)
+
+private fun createMockEventNotificationJson() = EventNotificationJson(
+    id = "id",
+    name = "name",
+    enabled = true,
+    groupId = "groupId",
+    householdId = "householdId",
+    options = listOf(createMockEventNotificationOptionJson())
+)
+
+private fun createMockEventNotificationOptionJson() =
+    EventNotificationJson.EventNotificationOptionJson(
+        testMessage = false,
+        webhookTask = false,
+        recipeCreated = false,
+        recipeUpdated = false,
+        recipeDeleted = false,
+        userSignup = false,
+        dataMigrations = false,
+        dataExport = false,
+        dataImport = false,
+        mealplanEntryCreated = false,
+        shoppingListCreated = false,
+        shoppingListUpdated = false,
+        shoppingListDeleted = false,
+        cookbookCreated = false,
+        cookbookUpdated = false,
+        cookbookDeleted = false,
+        tagCreated = false,
+        tagUpdated = false,
+        tagDeleted = false,
+        categoryCreated = false,
+        categoryUpdated = false,
+        categoryDeleted = false,
+        id = "id"
+    )
 
 private fun createMockPagedCookbooksResponseJson() = PagedResponseJson(
     page = 1,


### PR DESCRIPTION
This commit introduces the `getNotifications` function to the `HouseholdsApi` for fetching event notifications. It also includes the necessary data model `EventNotificationJson` and corresponding tests.