### PR TITLE
Add `RecipesApi` and `testScrapeUrl` endpoint

### DIFF
--- a/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/MealieClient.kt
+++ b/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/MealieClient.kt
@@ -7,6 +7,8 @@ import com.saintpatrck.mealie.client.api.auth.createAuthApi
 import com.saintpatrck.mealie.client.api.households.HouseholdsApi
 import com.saintpatrck.mealie.client.api.households.createHouseholdsApi
 import com.saintpatrck.mealie.client.api.model.MealieBearerTokens
+import com.saintpatrck.mealie.client.api.recipes.RecipesApi
+import com.saintpatrck.mealie.client.api.recipes.createRecipesApi
 import com.saintpatrck.mealie.client.api.user.UserApi
 import com.saintpatrck.mealie.client.api.user.createUserApi
 import com.saintpatrck.mealie.client.infrastructure.ktorfit.mealieKtorfit
@@ -76,5 +78,12 @@ class MealieClient internal constructor(
      */
     val householdsApi: HouseholdsApi by lazy {
         ktorfit.createHouseholdsApi()
+    }
+
+    /**
+     * The API for managing recipe information.
+     */
+    val recipesApi: RecipesApi by lazy {
+        ktorfit.createRecipesApi()
     }
 }

--- a/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/recipes/RecipesApi.kt
+++ b/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/recipes/RecipesApi.kt
@@ -1,0 +1,19 @@
+package com.saintpatrck.mealie.client.api.recipes
+
+import com.saintpatrck.mealie.client.api.model.MealieResponse
+import com.saintpatrck.mealie.client.api.recipes.model.TestScrapeUrlRequestJson
+import com.saintpatrck.mealie.client.api.recipes.model.TestScrapeUrlResponseJson
+import de.jensklingenberg.ktorfit.http.Body
+import de.jensklingenberg.ktorfit.http.Headers
+import de.jensklingenberg.ktorfit.http.POST
+
+/**
+ * The API for managing recipe information.
+ */
+interface RecipesApi {
+    @Headers("Content-Type: application/json")
+    @POST("recipes/test-scrape-url")
+    suspend fun testScrapeUrl(
+        @Body testScrapeUrlRequest: TestScrapeUrlRequestJson,
+    ): MealieResponse<TestScrapeUrlResponseJson>
+}

--- a/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/recipes/model/TestScrapeUrlRequestJson.kt
+++ b/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/recipes/model/TestScrapeUrlRequestJson.kt
@@ -1,0 +1,18 @@
+package com.saintpatrck.mealie.client.api.recipes.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Models a test scrape url request.
+ *
+ * @param url The URL to scrape.
+ * @param useOpenAi Whether to use OpenAI to scrape the URL.
+ */
+@Serializable
+data class TestScrapeUrlRequestJson(
+    @SerialName("url")
+    val url: String,
+    @SerialName("useOpenAI")
+    val useOpenAi: Boolean = false,
+)

--- a/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/recipes/model/TestScrapeUrlResponseJson.kt
+++ b/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/recipes/model/TestScrapeUrlResponseJson.kt
@@ -1,0 +1,49 @@
+package com.saintpatrck.mealie.client.api.recipes.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Models a recipe.
+ */
+@Serializable
+data class TestScrapeUrlResponseJson(
+    @SerialName("@context")
+    val context: String,
+    @SerialName("@type")
+    val type: String,
+    @SerialName("name")
+    val name: String,
+    @SerialName("image")
+    val image: List<String>,
+    @SerialName("description")
+    val description: String?,
+    @SerialName("prepTime")
+    val prepTime: String?,
+    @SerialName("cookTime")
+    val cookTime: String?,
+    @SerialName("totalTime")
+    val totalTime: String?,
+    @SerialName("recipeYield")
+    val recipeYield: String?,
+    @SerialName("author")
+    val author: String?,
+    @SerialName("recipeCategory")
+    val recipeCategory: String?,
+    @SerialName("recipeIngredient")
+    val recipeIngredient: List<String>?,
+    @SerialName("recipeInstructions")
+    val recipeInstructions: List<RecipeInstruction>?,
+) {
+
+    /**
+     * Models a recipe instruction.
+     */
+    @Serializable
+    data class RecipeInstruction(
+        @SerialName("@type")
+        val type: String,
+        @SerialName("text")
+        val text: String?,
+    )
+}

--- a/client/src/commonTest/kotlin/com/saintpatrck/mealie/client/api/recipes/RecipesApiTest.kt
+++ b/client/src/commonTest/kotlin/com/saintpatrck/mealie/client/api/recipes/RecipesApiTest.kt
@@ -1,0 +1,82 @@
+package com.saintpatrck.mealie.client.api.recipes
+
+import com.saintpatrck.mealie.client.api.base.BaseApiTest
+import com.saintpatrck.mealie.client.api.model.getOrThrow
+import com.saintpatrck.mealie.client.api.recipes.model.TestScrapeUrlRequestJson
+import com.saintpatrck.mealie.client.api.recipes.model.TestScrapeUrlResponseJson
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class RecipesApiTest : BaseApiTest() {
+
+    @Test
+    fun `testScrapeUrl should deserialize correctly`() = runTest {
+        createTestMealieClient(
+            responseJson = RECIPE_JSON,
+        )
+            .recipesApi
+            .testScrapeUrl(
+                testScrapeUrlRequest = TestScrapeUrlRequestJson(
+                    url = "mockUrl",
+                    useOpenAi = false,
+                )
+            )
+            .also { response ->
+                assertEquals(
+                    createMockRecipeJson(),
+                    response.getOrThrow(),
+                )
+            }
+    }
+}
+
+private const val RECIPE_JSON = """
+{
+    "@context": "https://schema.org/",
+    "@type": "Recipe",
+    "name": "BALTIMORE BLONDE FRIED CHICKEN",
+    "image": [
+        "https://images.ctfassets.net/8nq3bs98o7cv/6m5b87dnExetfdzn4dvPgX/8c694e17478abd939cc2219a312fd9a1/Baltimore_Blonde_Fried_Chicken"
+    ],
+    "description": "This recipe shows how Guinness can unlock unique flavours and new possibilities while cooking at home.",
+    "prepTime": "PT2 hours 45 mins",
+    "cookTime": "PT15 mins",
+    "totalTime": "PT2 hours 45 minsPT15 mins",
+    "recipeYield": "2-3",
+    "author": "Guinness Rebuild",
+    "recipeCategory": "Main",
+    "recipeIngredient": [
+        "BEER BRINE"
+    ],
+    "recipeInstructions": [
+        {
+            "@type": "HowToStep",
+            "text": "BEER BRINE"
+        }
+    ]
+}
+"""
+
+private fun createMockRecipeJson() = TestScrapeUrlResponseJson(
+    context = "https://schema.org/",
+    type = "Recipe",
+    name = "BALTIMORE BLONDE FRIED CHICKEN",
+    image = listOf("https://images.ctfassets.net/8nq3bs98o7cv/6m5b87dnExetfdzn4dvPgX/8c694e17478abd939cc2219a312fd9a1/Baltimore_Blonde_Fried_Chicken"),
+    description = "This recipe shows how Guinness can unlock unique flavours and new possibilities while cooking at home.",
+    prepTime = "PT2 hours 45 mins",
+    cookTime = "PT15 mins",
+    totalTime = "PT2 hours 45 minsPT15 mins",
+    recipeYield = "2-3",
+    author = "Guinness Rebuild",
+    recipeCategory = "Main",
+    recipeIngredient = listOf(
+        "BEER BRINE",
+    ),
+    recipeInstructions = listOf(
+        TestScrapeUrlResponseJson.RecipeInstruction(
+            type = "HowToStep",
+            text = "BEER BRINE"
+        ),
+    ),
+)


### PR DESCRIPTION
This commit introduces the `RecipesApi` with its first endpoint, `testScrapeUrl`.

It includes:
- `RecipesApi` interface for recipe-related operations.
- `testScrapeUrl` function to test scraping a URL for recipe information.
- `TestScrapeUrlRequestJson` data class for the request body of `testScrapeUrl`.
- `TestScrapeUrlResponseJson` data class for the response body of `testScrapeUrl`, including a nested `RecipeInstruction` class.
- Corresponding test cases in `RecipesApiTest` to ensure correct deserialization.
- Integration of `RecipesApi` into the `MealieClient`.