### PR TITLE
Add endpoint for creating recipes from HTML or JSON

### DIFF
--- a/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/recipes/RecipesApi.kt
+++ b/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/recipes/RecipesApi.kt
@@ -1,6 +1,7 @@
 package com.saintpatrck.mealie.client.api.recipes
 
 import com.saintpatrck.mealie.client.api.model.MealieResponse
+import com.saintpatrck.mealie.client.api.recipes.model.CreateRecipeFromHtmlOrJsonRequestJson
 import com.saintpatrck.mealie.client.api.recipes.model.TestScrapeUrlRequestJson
 import com.saintpatrck.mealie.client.api.recipes.model.TestScrapeUrlResponseJson
 import de.jensklingenberg.ktorfit.http.Body
@@ -11,9 +12,22 @@ import de.jensklingenberg.ktorfit.http.POST
  * The API for managing recipe information.
  */
 interface RecipesApi {
+
+    /**
+     * Test parse a URL for recipe information.
+     */
     @Headers("Content-Type: application/json")
     @POST("recipes/test-scrape-url")
     suspend fun testScrapeUrl(
         @Body testScrapeUrlRequest: TestScrapeUrlRequestJson,
     ): MealieResponse<TestScrapeUrlResponseJson>
+
+    /**
+     * Create a recipe from an HTML or JSON string.
+     */
+    @Headers("Content-Type: application/json")
+    @POST("recipes/create/html-or-json")
+    suspend fun createFromHtmlOrJson(
+        @Body request: CreateRecipeFromHtmlOrJsonRequestJson,
+    ): MealieResponse<String?>
 }

--- a/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/recipes/model/CreateRecipeFromHtmlOrJsonRequestJson.kt
+++ b/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/recipes/model/CreateRecipeFromHtmlOrJsonRequestJson.kt
@@ -1,0 +1,15 @@
+package com.saintpatrck.mealie.client.api.recipes.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Models a request to create a recipe from an HTML or JSON string.
+ */
+@Serializable
+data class CreateRecipeFromHtmlOrJsonRequestJson(
+    @SerialName("includeTags")
+    val includeTags: Boolean,
+    @SerialName("data")
+    val data: String,
+)

--- a/client/src/commonTest/kotlin/com/saintpatrck/mealie/client/api/recipes/RecipesApiTest.kt
+++ b/client/src/commonTest/kotlin/com/saintpatrck/mealie/client/api/recipes/RecipesApiTest.kt
@@ -2,6 +2,7 @@ package com.saintpatrck.mealie.client.api.recipes
 
 import com.saintpatrck.mealie.client.api.base.BaseApiTest
 import com.saintpatrck.mealie.client.api.model.getOrThrow
+import com.saintpatrck.mealie.client.api.recipes.model.CreateRecipeFromHtmlOrJsonRequestJson
 import com.saintpatrck.mealie.client.api.recipes.model.TestScrapeUrlRequestJson
 import com.saintpatrck.mealie.client.api.recipes.model.TestScrapeUrlResponseJson
 import kotlinx.coroutines.test.runTest
@@ -12,9 +13,7 @@ class RecipesApiTest : BaseApiTest() {
 
     @Test
     fun `testScrapeUrl should deserialize correctly`() = runTest {
-        createTestMealieClient(
-            responseJson = RECIPE_JSON,
-        )
+        createTestMealieClient(responseJson = RECIPE_JSON)
             .recipesApi
             .testScrapeUrl(
                 testScrapeUrlRequest = TestScrapeUrlRequestJson(
@@ -26,6 +25,24 @@ class RecipesApiTest : BaseApiTest() {
                 assertEquals(
                     createMockRecipeJson(),
                     response.getOrThrow(),
+                )
+            }
+    }
+
+    @Test
+    fun `createFromHtmlOrJson should deserialize correctly`() = runTest {
+        createTestMealieClient(responseJson = CREATE_RECIPE_FROM_HTML_OR_JSON_RESPONSE)
+            .recipesApi
+            .createFromHtmlOrJson(
+                request = CreateRecipeFromHtmlOrJsonRequestJson(
+                    includeTags = false,
+                    data = "data",
+                )
+            )
+            .also {
+                assertEquals(
+                    CREATE_RECIPE_FROM_HTML_OR_JSON_RESPONSE,
+                    it.getOrThrow(),
                 )
             }
     }
@@ -57,6 +74,7 @@ private const val RECIPE_JSON = """
     ]
 }
 """
+private const val CREATE_RECIPE_FROM_HTML_OR_JSON_RESPONSE = "mockResponse"
 
 private fun createMockRecipeJson() = TestScrapeUrlResponseJson(
     context = "https://schema.org/",


### PR DESCRIPTION
This commit introduces the `createFromHtmlOrJson` function to the `RecipesApi`.
It allows creating a recipe by providing recipe data as either an HTML or a JSON string.

A corresponding request model `CreateRecipeFromHtmlOrJsonRequestJson` and test cases have also been added.