### PR TITLE
Add updateUserImage endpoint to UserApi

### DIFF
--- a/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/user/UserApi.kt
+++ b/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/user/UserApi.kt
@@ -25,10 +25,12 @@ import de.jensklingenberg.ktorfit.http.Body
 import de.jensklingenberg.ktorfit.http.DELETE
 import de.jensklingenberg.ktorfit.http.GET
 import de.jensklingenberg.ktorfit.http.Headers
+import de.jensklingenberg.ktorfit.http.Multipart
 import de.jensklingenberg.ktorfit.http.POST
 import de.jensklingenberg.ktorfit.http.PUT
 import de.jensklingenberg.ktorfit.http.Path
 import de.jensklingenberg.ktorfit.http.Query
+import io.ktor.client.request.forms.MultiPartFormDataContent
 
 /**
  * Represents the API for managing user information.
@@ -162,6 +164,18 @@ interface UserApi {
     suspend fun resetPassword(
         @Body
         resetPasswordRequest: ResetPasswordRequestJson,
+    ): MealieResponse<Unit>
+
+    /**
+     * Updates the current user's profile image.
+     */
+    @Multipart
+    @POST("users/{userId}/image")
+    suspend fun updateUserImage(
+        @Path("userId")
+        userId: String,
+        @Body
+        image: MultiPartFormDataContent,
     ): MealieResponse<Unit>
 
     /**

--- a/client/src/commonTest/kotlin/com/saintpatrck/mealie/client/api/user/UserApiTest.kt
+++ b/client/src/commonTest/kotlin/com/saintpatrck/mealie/client/api/user/UserApiTest.kt
@@ -21,6 +21,8 @@ import com.saintpatrck.mealie.client.api.user.model.SetRatingRequestJson
 import com.saintpatrck.mealie.client.api.user.model.UpdatePasswordRequestJson
 import com.saintpatrck.mealie.client.api.user.model.UpdateUserRequestJson
 import com.saintpatrck.mealie.client.api.user.model.UserResponseJson
+import io.ktor.client.request.forms.MultiPartFormDataContent
+import io.ktor.client.request.forms.formData
 import kotlinx.coroutines.test.runTest
 import kotlinx.datetime.Instant
 import kotlin.test.Test
@@ -224,6 +226,29 @@ class UserApiTest : BaseApiTest() {
                     password = "password",
                     passwordConfirm = "passwordConfirm",
                 )
+            )
+            .also {
+                assertEquals(
+                    Unit,
+                    it.getOrNull(),
+                )
+            }
+    }
+
+    @Test
+    fun `updateUserImage should deserialize correctly`() = runTest {
+        createTestMealieClient(responseJson = "")
+            .userApi
+            .updateUserImage(
+                userId = "userId",
+                image = MultiPartFormDataContent(
+                    parts = formData {
+                        append(
+                            key = "profile",
+                            value = byteArrayOf(),
+                        )
+                    }
+                ),
             )
             .also {
                 assertEquals(


### PR DESCRIPTION
This commit introduces the `updateUserImage` function to the `UserApi` interface, allowing users to update their profile image.

It includes:
- The `updateUserImage` function in `UserApi`, which takes a `userId` and a `MultiPartFormDataContent` image.
- A corresponding test case `updateUserImage should deserialize correctly` in `UserApiTest` to ensure the endpoint functions as expected.