### PR TITLE
Add `createFromImage` endpoint and tests

### DIFF
--- a/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/recipes/RecipesApi.kt
+++ b/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/recipes/RecipesApi.kt
@@ -11,6 +11,7 @@ import de.jensklingenberg.ktorfit.http.Body
 import de.jensklingenberg.ktorfit.http.Headers
 import de.jensklingenberg.ktorfit.http.Multipart
 import de.jensklingenberg.ktorfit.http.POST
+import de.jensklingenberg.ktorfit.http.Query
 import io.ktor.client.request.forms.MultiPartFormDataContent
 
 /**
@@ -63,5 +64,17 @@ interface RecipesApi {
     @POST("recipes/create/zip")
     suspend fun createFromZip(
         @Body archive: MultiPartFormDataContent,
+    ): MealieResponse<Unit>
+
+    /**
+     * Creates a recipe from an image using OpenAI. Optionally, specify a language for it to
+     * translate the recipe to.
+     */
+    @Multipart
+    @POST("recipes/create/image")
+    suspend fun createFromImage(
+        @Query("translateLanguage")
+        translateLanguage: String?,
+        @Body image: MultiPartFormDataContent,
     ): MealieResponse<Unit>
 }

--- a/client/src/commonTest/kotlin/com/saintpatrck/mealie/client/api/recipes/RecipesApiTest.kt
+++ b/client/src/commonTest/kotlin/com/saintpatrck/mealie/client/api/recipes/RecipesApiTest.kt
@@ -115,6 +115,35 @@ class RecipesApiTest : BaseApiTest() {
                 )
             }
     }
+
+    @Test
+    fun `createRecipeFromImage should deserialize correctly`() = runTest {
+        val expectedLanguage = "en-US"
+        createTestMealieClient(
+            responseJson = "",
+            verifyRequest = { request ->
+                assertEquals(
+                    expectedLanguage,
+                    request.url.parameters["translateLanguage"]
+                )
+            }
+        )
+            .recipesApi
+            .createFromImage(
+                translateLanguage = expectedLanguage,
+                image = MultiPartFormDataContent(
+                    formData {
+                        append("image", byteArrayOf(0))
+                    }
+                )
+            )
+            .also { response ->
+                assertEquals(
+                    Unit,
+                    response.getOrThrow(),
+                )
+            }
+    }
 }
 
 private const val RECIPE_JSON = """


### PR DESCRIPTION
This commit introduces the `createFromImage` function to the `RecipesApi`, allowing for the creation of recipes from images using OpenAI, with an option to specify a translation language.

It includes:
- The `createFromImage` function in `RecipesApi`.
- A corresponding test case `createRecipeFromImage should deserialize correctly` in `RecipesApiTest` to ensure request parameters and response handling are correct.