### PR TITLE
Add RecipesApi getRecipes endpoint and update models

### DIFF
--- a/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/model/PagedResponseJson.kt
+++ b/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/model/PagedResponseJson.kt
@@ -12,6 +12,8 @@ data class PagedResponseJson<T>(
     val page: Int,
     @SerialName("per_page")
     val perPage: Int,
+    @SerialName("total")
+    val total: Int?,
     @SerialName("total_pages")
     val totalPages: Int,
     @SerialName("items")

--- a/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/model/RecipeJson.kt
+++ b/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/model/RecipeJson.kt
@@ -48,7 +48,7 @@ data class RecipeJson(
     @SerialName("slug")
     val slug: String,
     @SerialName("image")
-    val image: ByteArray?,
+    val image: String?,
     @SerialName("recipeServings")
     val recipeServings: Double,
     @SerialName("recipeYieldQuantity")
@@ -84,5 +84,5 @@ data class RecipeJson(
     @SerialName("updatedAt")
     val updatedAt: Instant,
     @SerialName("lastMade")
-    val lastMade: Instant,
+    val lastMade: Instant?,
 )

--- a/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/recipes/RecipesApi.kt
+++ b/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/recipes/RecipesApi.kt
@@ -1,6 +1,10 @@
 package com.saintpatrck.mealie.client.api.recipes
 
 import com.saintpatrck.mealie.client.api.model.MealieResponse
+import com.saintpatrck.mealie.client.api.model.OrderByNullPosition
+import com.saintpatrck.mealie.client.api.model.OrderDirection
+import com.saintpatrck.mealie.client.api.model.PagedResponseJson
+import com.saintpatrck.mealie.client.api.model.RecipeJson
 import com.saintpatrck.mealie.client.api.recipes.model.CreateRecipeFromHtmlOrJsonRequestJson
 import com.saintpatrck.mealie.client.api.recipes.model.CreateRecipeFromUrlBulkRequestJson
 import com.saintpatrck.mealie.client.api.recipes.model.CreateRecipeFromUrlBulkResponseJson
@@ -8,6 +12,7 @@ import com.saintpatrck.mealie.client.api.recipes.model.CreateRecipeFromUrlReques
 import com.saintpatrck.mealie.client.api.recipes.model.TestScrapeUrlRequestJson
 import com.saintpatrck.mealie.client.api.recipes.model.TestScrapeUrlResponseJson
 import de.jensklingenberg.ktorfit.http.Body
+import de.jensklingenberg.ktorfit.http.GET
 import de.jensklingenberg.ktorfit.http.Headers
 import de.jensklingenberg.ktorfit.http.Multipart
 import de.jensklingenberg.ktorfit.http.POST
@@ -77,4 +82,45 @@ interface RecipesApi {
         translateLanguage: String?,
         @Body image: MultiPartFormDataContent,
     ): MealieResponse<Unit>
+
+    /**
+     * Retrieve paged recipes.
+     */
+    @GET("recipes")
+    suspend fun getRecipes(
+        @Query("categories")
+        categories: List<String>? = null,
+        @Query("tags")
+        tags: List<String>? = null,
+        @Query("tools")
+        tools: List<String>? = null,
+        @Query("foods")
+        foods: List<String>? = null,
+        @Query("households")
+        households: List<String>? = null,
+        @Query("cookbook")
+        cookbook: String? = null,
+        @Query("requireAllCategories")
+        requireAllCategories: Boolean = false,
+        @Query("requireAllTags")
+        requireAllTags: Boolean = false,
+        @Query("requireAllTools")
+        requireAllTools: Boolean = false,
+        @Query("requireAllFoods")
+        requireAllFoods: Boolean = false,
+        @Query("search")
+        search: String? = null,
+        @Query("orderBy")
+        orderBy: String? = null,
+        @Query("orderByNullPosition")
+        orderByNullPosition: OrderByNullPosition? = null,
+        @Query("orderDirection")
+        orderDirection: OrderDirection = OrderDirection.DESC,
+        @Query("paginationSeed")
+        paginationSeed: String? = null,
+        @Query("page")
+        page: Int = 1,
+        @Query("perPage")
+        perPage: Int = 50,
+    ): MealieResponse<PagedResponseJson<RecipeJson>>
 }

--- a/client/src/commonTest/kotlin/com/saintpatrck/mealie/client/api/households/HouseholdsApiTest.kt
+++ b/client/src/commonTest/kotlin/com/saintpatrck/mealie/client/api/households/HouseholdsApiTest.kt
@@ -7,16 +7,13 @@ import com.saintpatrck.mealie.client.api.households.model.CreateCookbookRequestJ
 import com.saintpatrck.mealie.client.api.households.model.EventNotificationJson
 import com.saintpatrck.mealie.client.api.households.model.UpdateCookbookRequestJson
 import com.saintpatrck.mealie.client.api.model.PagedResponseJson
-import com.saintpatrck.mealie.client.api.model.RecipeCategoryJson
-import com.saintpatrck.mealie.client.api.model.RecipeJson
-import com.saintpatrck.mealie.client.api.model.RecipeTagJson
-import com.saintpatrck.mealie.client.api.model.RecipeToolJson
 import com.saintpatrck.mealie.client.api.model.getOrNull
 import com.saintpatrck.mealie.client.api.model.getOrThrow
+import com.saintpatrck.mealie.client.api.util.RECIPE_JSON
+import com.saintpatrck.mealie.client.api.util.createMockRecipeJson
 import io.ktor.client.engine.mock.toByteArray
 import io.ktor.http.HttpMethod
 import kotlinx.coroutines.test.runTest
-import kotlinx.datetime.Instant
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -294,54 +291,7 @@ private val COOKBOOK_WITH_RECIPES_JSON = """
     "parts": []
   },
   "recipes": [
-    {
-      "id": "id",
-      "userId": "userId",
-      "householdId": "householdId",
-      "groupId": "groupId",
-      "name": "name",
-      "slug": "slug",
-      "image": null,
-      "recipeServings": 0,
-      "recipeYieldQuantity": 0,
-      "recipeYield": "recipeYield",
-      "totalTime": "totalTime",
-      "prepTime": "prepTime",
-      "cookTime": "cookTime",
-      "performTime": "performTime",
-      "description": "description",
-      "recipeCategory": [
-        {
-          "id": "id",
-          "name": "name",
-          "slug": "slug"
-        }
-      ],
-      "tags": [
-        {
-          "id": "id",
-          "name": "name",
-          "slug": "slug"
-        }
-      ],
-      "tools": [
-        {
-          "id": "id",
-          "name": "name",
-          "slug": "slug",
-          "householdsWithTool": [
-            "householdsWithTool"
-          ]
-        }
-      ],
-      "rating": 0.0,
-      "orgURL": "orgURL",
-      "dateAdded": "2019-08-24",
-      "dateUpdated": "2019-08-24T14:15:22Z",
-      "createdAt": "2019-08-24T14:15:22Z",
-      "updatedAt": "2019-08-24T14:15:22Z",
-      "lastMade": "2019-08-24T14:15:22Z"
-    }
+    $RECIPE_JSON  
   ]
 }
 """
@@ -351,6 +301,7 @@ private fun createMockPagedEventNotificationsResponse() = PagedResponseJson(
     page = 1,
     perPage = 10,
     totalPages = 0,
+    total = 0,
     items = listOf(createMockEventNotificationJson()),
     next = "next",
     previous = "previous",
@@ -396,6 +347,7 @@ private fun createMockPagedCookbooksResponseJson() = PagedResponseJson(
     page = 1,
     perPage = 10,
     totalPages = 0,
+    total = 0,
     items = listOf(createMockCookbookJson()),
     next = "next",
     previous = "previous"
@@ -424,51 +376,4 @@ private fun createMockCookbookWithRecipesJson() = CookbookWithRecipesJson(
     groupId = "groupId",
     householdId = "householdId",
     recipes = listOf(createMockRecipeJson())
-)
-
-private fun createMockRecipeJson() = RecipeJson(
-    id = "id",
-    userId = "userId",
-    householdId = "householdId",
-    groupId = "groupId",
-    name = "name",
-    slug = "slug",
-    image = null,
-    recipeServings = 0.0,
-    recipeYieldQuantity = 0.0,
-    recipeYield = "recipeYield",
-    totalTime = "totalTime",
-    prepTime = "prepTime",
-    cookTime = "cookTime",
-    performTime = "performTime",
-    description = "description",
-    recipeCategory = listOf(createMockRecipeCategory()),
-    tags = listOf(createMockRecipeTag()),
-    tools = listOf(createMockRecipeTool()),
-    rating = 0.0,
-    orgUrl = "orgURL",
-    dateAdded = "2019-08-24",
-    dateUpdated = Instant.parse("2019-08-24T14:15:22Z"),
-    createdAt = Instant.parse("2019-08-24T14:15:22Z"),
-    updatedAt = Instant.parse("2019-08-24T14:15:22Z"),
-    lastMade = Instant.parse("2019-08-24T14:15:22Z"),
-)
-
-private fun createMockRecipeCategory() = RecipeCategoryJson(
-    id = "id",
-    name = "name",
-    slug = "slug",
-)
-
-private fun createMockRecipeTag() = RecipeTagJson(
-    id = "id",
-    name = "name",
-    slug = "slug",
-)
-
-private fun createMockRecipeTool() = RecipeToolJson(
-    id = "id",
-    name = "name",
-    slug = "slug",
-    householdsWithTool = listOf("householdsWithTool")
 )

--- a/client/src/commonTest/kotlin/com/saintpatrck/mealie/client/api/recipes/RecipesApiTest.kt
+++ b/client/src/commonTest/kotlin/com/saintpatrck/mealie/client/api/recipes/RecipesApiTest.kt
@@ -1,6 +1,7 @@
 package com.saintpatrck.mealie.client.api.recipes
 
 import com.saintpatrck.mealie.client.api.base.BaseApiTest
+import com.saintpatrck.mealie.client.api.model.PagedResponseJson
 import com.saintpatrck.mealie.client.api.model.getOrThrow
 import com.saintpatrck.mealie.client.api.recipes.model.CreateRecipeFromHtmlOrJsonRequestJson
 import com.saintpatrck.mealie.client.api.recipes.model.CreateRecipeFromUrlBulkRequestJson
@@ -8,6 +9,8 @@ import com.saintpatrck.mealie.client.api.recipes.model.CreateRecipeFromUrlBulkRe
 import com.saintpatrck.mealie.client.api.recipes.model.CreateRecipeFromUrlRequestJson
 import com.saintpatrck.mealie.client.api.recipes.model.TestScrapeUrlRequestJson
 import com.saintpatrck.mealie.client.api.recipes.model.TestScrapeUrlResponseJson
+import com.saintpatrck.mealie.client.api.util.RECIPE_JSON
+import com.saintpatrck.mealie.client.api.util.createMockRecipeJson
 import io.ktor.client.request.forms.MultiPartFormDataContent
 import io.ktor.client.request.forms.formData
 import kotlinx.coroutines.test.runTest
@@ -18,7 +21,7 @@ class RecipesApiTest : BaseApiTest() {
 
     @Test
     fun `testScrapeUrl should deserialize correctly`() = runTest {
-        createTestMealieClient(responseJson = RECIPE_JSON)
+        createTestMealieClient(responseJson = TEST_SCRAPE_URL_RESPONSE_JSON)
             .recipesApi
             .testScrapeUrl(
                 testScrapeUrlRequest = TestScrapeUrlRequestJson(
@@ -28,7 +31,7 @@ class RecipesApiTest : BaseApiTest() {
             )
             .also { response ->
                 assertEquals(
-                    createMockRecipeJson(),
+                    createMockTestScrapeUrlResponseJson(),
                     response.getOrThrow(),
                 )
             }
@@ -144,9 +147,22 @@ class RecipesApiTest : BaseApiTest() {
                 )
             }
     }
+
+    @Test
+    fun `getRecipes should deserialize correctly`() = runTest {
+        createTestMealieClient(responseJson = PAGED_RECIPE_RESPONSE_JSON)
+            .recipesApi
+            .getRecipes()
+            .also { response ->
+                assertEquals(
+                    createMockPagedRecipeResponseJson(),
+                    response.getOrThrow(),
+                )
+            }
+    }
 }
 
-private const val RECIPE_JSON = """
+private const val TEST_SCRAPE_URL_RESPONSE_JSON = """
 {
     "@context": "https://schema.org/",
     "@type": "Recipe",
@@ -179,7 +195,22 @@ private const val CREATE_RECIPE_FROM_URL_BULK_JSON_RESPONSE = """
 }
 """
 
-private fun createMockRecipeJson() = TestScrapeUrlResponseJson(
+private val PAGED_RECIPE_RESPONSE_JSON = """
+{
+    "page": 1,
+    "per_page": 10,
+    "total": 6,
+    "total_pages": 0,
+    "items": [
+        $RECIPE_JSON
+    ],
+    "next": "next",
+    "previous": "previous"
+}
+"""
+    .trimIndent()
+
+private fun createMockTestScrapeUrlResponseJson() = TestScrapeUrlResponseJson(
     context = "https://schema.org/",
     type = "Recipe",
     name = "BALTIMORE BLONDE FRIED CHICKEN",
@@ -200,4 +231,14 @@ private fun createMockRecipeJson() = TestScrapeUrlResponseJson(
             text = "BEER BRINE"
         ),
     ),
+)
+
+private fun createMockPagedRecipeResponseJson() = PagedResponseJson(
+    page = 1,
+    perPage = 10,
+    totalPages = 0,
+    total = 6,
+    items = listOf(createMockRecipeJson()),
+    next = "next",
+    previous = "previous",
 )

--- a/client/src/commonTest/kotlin/com/saintpatrck/mealie/client/api/user/UserApiTest.kt
+++ b/client/src/commonTest/kotlin/com/saintpatrck/mealie/client/api/user/UserApiTest.kt
@@ -564,6 +564,7 @@ private fun createMockPagedUserResponseJson(): PagedResponseJson<UserResponseJso
         page = 1,
         perPage = 10,
         totalPages = 0,
+        total = 0,
         items = listOf(createMockUserResponseJson()),
         next = "string",
         previous = "string",

--- a/client/src/commonTest/kotlin/com/saintpatrck/mealie/client/api/util/RecipeJsonUtils.kt
+++ b/client/src/commonTest/kotlin/com/saintpatrck/mealie/client/api/util/RecipeJsonUtils.kt
@@ -1,0 +1,121 @@
+package com.saintpatrck.mealie.client.api.util
+
+import com.saintpatrck.mealie.client.api.model.RecipeCategoryJson
+import com.saintpatrck.mealie.client.api.model.RecipeJson
+import com.saintpatrck.mealie.client.api.model.RecipeTagJson
+import com.saintpatrck.mealie.client.api.model.RecipeToolJson
+import kotlinx.datetime.Instant
+
+/**
+ * JSON string representing a [RecipeJson] for testing.
+ */
+val RECIPE_JSON = """
+{
+  "id": "id",
+  "userId": "userId",
+  "householdId": "householdId",
+  "groupId": "groupId",
+  "name": "name",
+  "slug": "slug",
+  "image": null,
+  "recipeServings": 0,
+  "recipeYieldQuantity": 0,
+  "recipeYield": "recipeYield",
+  "totalTime": "totalTime",
+  "prepTime": "prepTime",
+  "cookTime": "cookTime",
+  "performTime": "performTime",
+  "description": "description",
+  "recipeCategory": [
+    {
+      "id": "id",
+      "name": "name",
+      "slug": "slug"
+    }
+  ],
+  "tags": [
+    {
+      "id": "id",
+      "name": "name",
+      "slug": "slug"
+    }
+  ],
+  "tools": [
+    {
+      "id": "id",
+      "name": "name",
+      "slug": "slug",
+      "householdsWithTool": [
+        "householdsWithTool"
+      ]
+    }
+  ],
+  "rating": 0.0,
+  "orgURL": "orgURL",
+  "dateAdded": "2019-08-24",
+  "dateUpdated": "2019-08-24T14:15:22Z",
+  "createdAt": "2019-08-24T14:15:22Z",
+  "updatedAt": "2019-08-24T14:15:22Z",
+  "lastMade": "2019-08-24T14:15:22Z"
+}
+"""
+    .trimIndent()
+
+/**
+ * Create a mock [RecipeJson] for testing.
+ */
+fun createMockRecipeJson() = RecipeJson(
+    id = "id",
+    userId = "userId",
+    householdId = "householdId",
+    groupId = "groupId",
+    name = "name",
+    slug = "slug",
+    image = null,
+    recipeServings = 0.0,
+    recipeYieldQuantity = 0.0,
+    recipeYield = "recipeYield",
+    totalTime = "totalTime",
+    prepTime = "prepTime",
+    cookTime = "cookTime",
+    performTime = "performTime",
+    description = "description",
+    recipeCategory = listOf(createMockRecipeCategory()),
+    tags = listOf(createMockRecipeTag()),
+    tools = listOf(createMockRecipeTool()),
+    rating = 0.0,
+    orgUrl = "orgURL",
+    dateAdded = "2019-08-24",
+    dateUpdated = Instant.parse("2019-08-24T14:15:22Z"),
+    createdAt = Instant.parse("2019-08-24T14:15:22Z"),
+    updatedAt = Instant.parse("2019-08-24T14:15:22Z"),
+    lastMade = Instant.parse("2019-08-24T14:15:22Z"),
+)
+
+/**
+ * Create a mock [RecipeCategoryJson] for testing.
+ */
+fun createMockRecipeCategory() = RecipeCategoryJson(
+    id = "id",
+    name = "name",
+    slug = "slug",
+)
+
+/**
+ * Create a mock [RecipeTagJson] for testing.
+ */
+fun createMockRecipeTag() = RecipeTagJson(
+    id = "id",
+    name = "name",
+    slug = "slug",
+)
+
+/**
+ * Create a mock [RecipeToolJson] for testing.
+ */
+fun createMockRecipeTool() = RecipeToolJson(
+    id = "id",
+    name = "name",
+    slug = "slug",
+    householdsWithTool = listOf("householdsWithTool")
+)


### PR DESCRIPTION
This commit introduces the `getRecipes` function to the `RecipesApi` for fetching paged recipes.

It also includes the following model changes:
- `RecipeJson.image` is now a `String?` instead of `ByteArray?`.
- `RecipeJson.lastMade` is now nullable (`Instant?`).
- `PagedResponseJson.total` is now a nullable `Int?`.

Corresponding tests and test utility functions for `RecipeJson` have been added.