### PR TITLE
Add createRecipe endpoint and tests

### DIFF
--- a/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/recipes/RecipesApi.kt
+++ b/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/recipes/RecipesApi.kt
@@ -9,6 +9,7 @@ import com.saintpatrck.mealie.client.api.recipes.model.CreateRecipeFromHtmlOrJso
 import com.saintpatrck.mealie.client.api.recipes.model.CreateRecipeFromUrlBulkRequestJson
 import com.saintpatrck.mealie.client.api.recipes.model.CreateRecipeFromUrlBulkResponseJson
 import com.saintpatrck.mealie.client.api.recipes.model.CreateRecipeFromUrlRequestJson
+import com.saintpatrck.mealie.client.api.recipes.model.CreateRecipeRequestJson
 import com.saintpatrck.mealie.client.api.recipes.model.TestScrapeUrlRequestJson
 import com.saintpatrck.mealie.client.api.recipes.model.TestScrapeUrlResponseJson
 import de.jensklingenberg.ktorfit.http.Body
@@ -85,6 +86,26 @@ interface RecipesApi {
 
     /**
      * Retrieve paged recipes.
+     *
+     * @param categories a list of categories to filter by. Defaults to `null`.
+     * @param tags a list of tags to filter by. Defaults to `null`.
+     * @param tools a list of tools to filter by. Defaults to `null`.
+     * @param foods a list of foods to filter by. Defaults to `null`.
+     * @param households a list of households to filter by. Defaults to `null`.
+     * @param cookbook the cookbook to filter by. Defaults to `null`.
+     * @param requireAllCategories whether to require all categories in the list. Defaults to `false`.
+     * @param requireAllTags whether to require all tags in the list. Defaults to `false`.
+     * @param requireAllTools whether to require all tools in the list. Defaults to `false`.
+     * @param requireAllFoods whether to require all foods in the list. Defaults to `false`.
+     * @param search the search query. Defaults to `null`.
+     * @param orderBy the field to order by. Defaults to `null`.
+     * @param orderByNullPosition the position of null values in the ordering. Defaults to `null`.
+     * @param orderDirection the direction of the ordering. Defaults to [OrderDirection.DESC].
+     * @param paginationSeed the seed for pagination. Defaults to `null`.
+     * @param page the page number. Defaults to `1`.
+     * @param perPage the number of items per page. Defaults to `50`.
+     *
+     * @return a paged list of recipes
      */
     @GET("recipes")
     suspend fun getRecipes(
@@ -123,4 +144,15 @@ interface RecipesApi {
         @Query("perPage")
         perPage: Int = 50,
     ): MealieResponse<PagedResponseJson<RecipeJson>>
+
+    /**
+     * Creates a new recipe.
+     *
+     * @return Mealie response containing the slug of the created recipe.
+     */
+    @Headers("Content-Type: application/json")
+    @POST("recipes")
+    suspend fun createRecipe(
+        @Body recipe: CreateRecipeRequestJson,
+    ): MealieResponse<String>
 }

--- a/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/recipes/model/CreateRecipeRequestJson.kt
+++ b/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/recipes/model/CreateRecipeRequestJson.kt
@@ -1,0 +1,38 @@
+package com.saintpatrck.mealie.client.api.recipes.model
+
+import com.saintpatrck.mealie.client.api.model.RecipeCategoryJson
+import com.saintpatrck.mealie.client.api.model.RecipeTagJson
+import com.saintpatrck.mealie.client.api.model.RecipeToolJson
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Models a request to create a recipe.
+ */
+@Serializable
+data class CreateRecipeRequestJson(
+    @SerialName("name")
+    val name: String,
+    @SerialName("householdId")
+    val householdId: String? = null,
+    @SerialName("groupId")
+    val groupId: String? = null,
+    @SerialName("recipeYield")
+    val recipeYield: String? = null,
+    @SerialName("totalTime")
+    val totalTime: String? = null,
+    @SerialName("prepTime")
+    val prepTime: String? = null,
+    @SerialName("cookTime")
+    val cookTime: String? = null,
+    @SerialName("performTime")
+    val performTime: String? = null,
+    @SerialName("recipeCategory")
+    val recipeCategory: List<RecipeCategoryJson> = emptyList(),
+    @SerialName("tags")
+    val tags: List<RecipeTagJson> = emptyList(),
+    @SerialName("tools")
+    val tools: List<RecipeToolJson> = emptyList(),
+    @SerialName("rating")
+    val rating: Double? = null,
+)

--- a/client/src/commonTest/kotlin/com/saintpatrck/mealie/client/api/recipes/RecipesApiTest.kt
+++ b/client/src/commonTest/kotlin/com/saintpatrck/mealie/client/api/recipes/RecipesApiTest.kt
@@ -7,6 +7,7 @@ import com.saintpatrck.mealie.client.api.recipes.model.CreateRecipeFromHtmlOrJso
 import com.saintpatrck.mealie.client.api.recipes.model.CreateRecipeFromUrlBulkRequestJson
 import com.saintpatrck.mealie.client.api.recipes.model.CreateRecipeFromUrlBulkResponseJson
 import com.saintpatrck.mealie.client.api.recipes.model.CreateRecipeFromUrlRequestJson
+import com.saintpatrck.mealie.client.api.recipes.model.CreateRecipeRequestJson
 import com.saintpatrck.mealie.client.api.recipes.model.TestScrapeUrlRequestJson
 import com.saintpatrck.mealie.client.api.recipes.model.TestScrapeUrlResponseJson
 import com.saintpatrck.mealie.client.api.util.RECIPE_JSON
@@ -160,6 +161,21 @@ class RecipesApiTest : BaseApiTest() {
                 )
             }
     }
+
+    @Test
+    fun `createRecipe should deserialize correctly`() = runTest {
+        createTestMealieClient(responseJson = "mockSlug")
+            .recipesApi
+            .createRecipe(
+                recipe = createMockCreateRecipeRequestJson(),
+            )
+            .also { response ->
+                assertEquals(
+                    "mockSlug",
+                    response.getOrThrow(),
+                )
+            }
+    }
 }
 
 private const val TEST_SCRAPE_URL_RESPONSE_JSON = """
@@ -241,4 +257,19 @@ private fun createMockPagedRecipeResponseJson() = PagedResponseJson(
     items = listOf(createMockRecipeJson()),
     next = "next",
     previous = "previous",
+)
+
+private fun createMockCreateRecipeRequestJson() = CreateRecipeRequestJson(
+    name = "mockName",
+    householdId = "mockHouseholdId",
+    groupId = "mockGroupId",
+    recipeYield = "mockRecipeYield",
+    totalTime = "mockTotalTime",
+    prepTime = "mockPrepTime",
+    cookTime = "mockCookTime",
+    performTime = "mockPerformTime",
+    recipeCategory = emptyList(),
+    tags = emptyList(),
+    tools = emptyList(),
+    rating = 0.0,
 )


### PR DESCRIPTION
This commit introduces the `createRecipe` endpoint to the `RecipesApi` for creating new recipes.

It includes:
- `CreateRecipeRequestJson` data class for the request body.
- The `createRecipe` function in `RecipesApi`.
- A corresponding test case `createRecipe should deserialize correctly` in `RecipesApiTest`.
- Expanded KDoc for the `getRecipes` function to include all query parameters.