### PR TITLE
Add `updateRecipes` endpoint and models

### DIFF
--- a/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/model/MultiPurposeLabelSummaryJson.kt
+++ b/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/model/MultiPurposeLabelSummaryJson.kt
@@ -1,0 +1,19 @@
+package com.saintpatrck.mealie.client.api.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Models a multi-purpose label.
+ */
+@Serializable
+data class MultiPurposeLabelSummaryJson(
+    @SerialName("name")
+    val name: String,
+    @SerialName("color")
+    val color: String = "#959595",
+    @SerialName("groupId")
+    val groupId: String,
+    @SerialName("id")
+    val id: String,
+)

--- a/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/recipes/RecipesApi.kt
+++ b/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/recipes/RecipesApi.kt
@@ -9,7 +9,7 @@ import com.saintpatrck.mealie.client.api.recipes.model.CreateRecipeFromHtmlOrJso
 import com.saintpatrck.mealie.client.api.recipes.model.CreateRecipeFromUrlBulkRequestJson
 import com.saintpatrck.mealie.client.api.recipes.model.CreateRecipeFromUrlBulkResponseJson
 import com.saintpatrck.mealie.client.api.recipes.model.CreateRecipeFromUrlRequestJson
-import com.saintpatrck.mealie.client.api.recipes.model.CreateRecipeRequestJson
+import com.saintpatrck.mealie.client.api.recipes.model.RecipeRequestJson
 import com.saintpatrck.mealie.client.api.recipes.model.TestScrapeUrlRequestJson
 import com.saintpatrck.mealie.client.api.recipes.model.TestScrapeUrlResponseJson
 import de.jensklingenberg.ktorfit.http.Body
@@ -17,6 +17,7 @@ import de.jensklingenberg.ktorfit.http.GET
 import de.jensklingenberg.ktorfit.http.Headers
 import de.jensklingenberg.ktorfit.http.Multipart
 import de.jensklingenberg.ktorfit.http.POST
+import de.jensklingenberg.ktorfit.http.PUT
 import de.jensklingenberg.ktorfit.http.Query
 import io.ktor.client.request.forms.MultiPartFormDataContent
 
@@ -153,6 +154,15 @@ interface RecipesApi {
     @Headers("Content-Type: application/json")
     @POST("recipes")
     suspend fun createRecipe(
-        @Body recipe: CreateRecipeRequestJson,
+        @Body recipe: RecipeRequestJson,
     ): MealieResponse<String>
+
+    /**
+     * Bulk update recipes.
+     */
+    @Headers("Content-Type: application/json")
+    @PUT("recipes")
+    suspend fun updateRecipes(
+        @Body recipes: List<RecipeRequestJson>,
+    ): MealieResponse<Unit>
 }

--- a/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/recipes/model/RecipeAssetJson.kt
+++ b/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/recipes/model/RecipeAssetJson.kt
@@ -1,0 +1,17 @@
+package com.saintpatrck.mealie.client.api.recipes.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Models an asset for a recipe.
+ */
+@Serializable
+data class RecipeAssetJson(
+    @SerialName("name")
+    val name: String,
+    @SerialName("icon")
+    val icon: String,
+    @SerialName("fileName")
+    val fileName: String,
+)

--- a/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/recipes/model/RecipeIngredientJson.kt
+++ b/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/recipes/model/RecipeIngredientJson.kt
@@ -1,0 +1,98 @@
+package com.saintpatrck.mealie.client.api.recipes.model
+
+import com.saintpatrck.mealie.client.api.model.MultiPurposeLabelSummaryJson
+import kotlinx.datetime.Instant
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonNames
+
+/**
+ * Models a recipe ingredient.
+ */
+@Serializable
+data class RecipeIngredientJson(
+    @SerialName("quantity")
+    val quantity: Double? = 1.0,
+    @SerialName("unit")
+    val unit: IngredientUnitJson? = null,
+    @SerialName("food")
+    val food: IngredientFoodJson? = null,
+    @SerialName("note")
+    val note: String? = null,
+    @SerialName("isFood")
+    val isFood: Boolean? = null,
+    @SerialName("disableAmount")
+    val disableAmount: Boolean = true,
+    @SerialName("display")
+    val display: String = "",
+    @SerialName("title")
+    val title: String? = null,
+    @SerialName("originalText")
+    val originalText: String? = null,
+    @SerialName("referenceId")
+    val referenceId: String,
+) {
+
+
+    /**
+     * Models an ingredient food.
+     */
+    @Serializable
+    data class IngredientFoodJson(
+        @SerialName("id")
+        val id: String,
+        @SerialName("name")
+        val name: String,
+        @SerialName("pluralName")
+        val pluralName: String,
+        @SerialName("description")
+        val description: String,
+        @SerialName("extras")
+        val extras: String,
+        @SerialName("labelId")
+        val labelId: String,
+        @SerialName("aliases")
+        val aliases: List<String> = emptyList(),
+        @SerialName("householdsWithIngredientFood")
+        val householdsWithIngredientFood: List<String> = emptyList(),
+        @SerialName("label")
+        val label: MultiPurposeLabelSummaryJson,
+        @SerialName("createdAt")
+        val createdAt: Instant? = null,
+        @SerialName("updatedAt")
+        @JsonNames("update_at")
+        val updatedAt: Instant? = null,
+    )
+
+    /**
+     * Models an ingredient unit of measure.
+     */
+    @Serializable
+    data class IngredientUnitJson(
+        @SerialName("id")
+        val id: String,
+        @SerialName("name")
+        val name: String,
+        @SerialName("pluralName")
+        val pluralName: String,
+        @SerialName("description")
+        val description: String,
+        @SerialName("extras")
+        val extras: String,
+        @SerialName("fraction")
+        val fraction: Boolean = true,
+        @SerialName("abbreviation")
+        val abbreviation: String = "",
+        @SerialName("pluralAbbreviation")
+        val pluralAbbreviation: String = "",
+        @SerialName("useAbbreviation")
+        val useAbbreviation: Boolean = false,
+        @SerialName("aliases")
+        val aliases: List<String> = emptyList(),
+        @SerialName("createdAt")
+        val createdAt: Instant? = null,
+        @SerialName("updatedAt")
+        @JsonNames("update_at")
+        val updatedAt: Instant? = null,
+    )
+}

--- a/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/recipes/model/RecipeInstructionJson.kt
+++ b/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/recipes/model/RecipeInstructionJson.kt
@@ -1,0 +1,19 @@
+package com.saintpatrck.mealie.client.api.recipes.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Models a recipe instruction.
+ */
+@Serializable
+data class RecipeInstructionJson(
+    @SerialName("id")
+    val id: String? = null,
+    @SerialName("title")
+    val title: String = "",
+    @SerialName("text")
+    val text: String,
+    @SerialName("ingredientReferences")
+    val ingredientReferences: List<String> = emptyList(),
+)

--- a/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/recipes/model/RecipeNoteJson.kt
+++ b/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/recipes/model/RecipeNoteJson.kt
@@ -1,0 +1,15 @@
+package com.saintpatrck.mealie.client.api.recipes.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Models a note for a recipe.
+ */
+@Serializable
+data class RecipeNoteJson(
+    @SerialName("title")
+    val title: String,
+    @SerialName("text")
+    val text: String,
+)

--- a/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/recipes/model/RecipeNutritionJson.kt
+++ b/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/recipes/model/RecipeNutritionJson.kt
@@ -1,0 +1,31 @@
+package com.saintpatrck.mealie.client.api.recipes.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Models nutritional information for a recipe.
+ */
+@Serializable
+data class RecipeNutritionJson(
+    @SerialName("calories")
+    val calories: String?,
+    @SerialName("carbohydrateContent")
+    val carbohydrateContent: String?,
+    @SerialName("cholesterolContent")
+    val cholesterolContent: String?,
+    @SerialName("fatContent")
+    val fatContent: String?,
+    @SerialName("fiberContent")
+    val fiberContent: String?,
+    @SerialName("proteinContent")
+    val proteinContent: String?,
+    @SerialName("saturatedFatContent")
+    val saturatedFatContent: String?,
+    @SerialName("sodiumContent")
+    val sodiumContent: String?,
+    @SerialName("sugarContent")
+    val sugarContent: String?,
+    @SerialName("unsaturatedFatContent")
+    val unsaturatedFatContent: String?,
+)

--- a/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/recipes/model/RecipeRequestJson.kt
+++ b/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/recipes/model/RecipeRequestJson.kt
@@ -1,0 +1,143 @@
+package com.saintpatrck.mealie.client.api.recipes.model
+
+import com.saintpatrck.mealie.client.api.model.RecipeCategoryJson
+import com.saintpatrck.mealie.client.api.model.RecipeTagJson
+import com.saintpatrck.mealie.client.api.model.RecipeToolJson
+import kotlinx.datetime.Instant
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Models a recipe request.
+ *
+ * @property id The ID of the recipe.
+ * @property userId The ID of the user who added the recipe.
+ * @property householdId The ID of the household that the recipe belongs to.
+ * @property groupId The ID of the group that the recipe belongs to.
+ * @property name The name of the recipe.
+ * @property slug The slug associated with the recipe.
+ * @property image The image associated with the recipe.
+ * @property recipeServings The number of servings in the recipe.
+ * @property recipeYieldQuantity The quantity of the recipe yield.
+ * @property recipeYield The yield of the recipe.
+ * @property totalTime The total time it takes to make the recipe.
+ * @property prepTime The preparation time of the recipe.
+ * @property cookTime The cooking time of the recipe.
+ * @property performTime The active time required for the recipe.
+ * @property description The description of the recipe.
+ * @property recipeCategory The categories the recipe belongs to.
+ * @property tags The tags associated with the recipe.
+ * @property tools The tools required to make the recipe.
+ * @property rating The overall rating of the recipe.
+ * @property orgUrl The original URL associated with the recipe.
+ * @property dateAdded The date when the recipe was added.
+ * @property dateUpdated The date when the recipe was last updated.
+ * @property createdAt The creation date of the recipe.
+ * @property updatedAt The last update date of the recipe.
+ * @property lastMade The date when the recipe was last made.
+ */
+@Serializable
+data class RecipeRequestJson(
+    @SerialName("id")
+    val id: String? = null,
+    @SerialName("userId")
+    val userId: String,
+    @SerialName("householdId")
+    val householdId: String,
+    @SerialName("groupId")
+    val groupId: String,
+    @SerialName("name")
+    val name: String? = null,
+    @SerialName("slug")
+    val slug: String = "",
+    @SerialName("image")
+    val image: String? = null,
+    @SerialName("recipeServings")
+    val recipeServings: Double = 0.0,
+    @SerialName("recipeYieldQuantity")
+    val recipeYieldQuantity: Double = 0.0,
+    @SerialName("recipeYield")
+    val recipeYield: String? = null,
+    @SerialName("totalTime")
+    val totalTime: String? = null,
+    @SerialName("prepTime")
+    val prepTime: String? = null,
+    @SerialName("cookTime")
+    val cookTime: String? = null,
+    @SerialName("performTime")
+    val performTime: String? = null,
+    @SerialName("description")
+    val description: String = "",
+    @SerialName("recipeCategory")
+    val recipeCategory: List<RecipeCategoryJson>? = emptyList(),
+    @SerialName("tags")
+    val tags: List<RecipeTagJson>? = emptyList(),
+    @SerialName("tools")
+    val tools: List<RecipeToolJson> = emptyList(),
+    @SerialName("rating")
+    val rating: Double? = null,
+    @SerialName("orgURL")
+    val orgUrl: String? = null,
+    @SerialName("dateAdded")
+    val dateAdded: String? = null,
+    @SerialName("dateUpdated")
+    val dateUpdated: Instant? = null,
+    @SerialName("createdAt")
+    val createdAt: Instant? = null,
+    @SerialName("updatedAt")
+    val updatedAt: Instant? = null,
+    @SerialName("lastMade")
+    val lastMade: Instant? = null,
+    @SerialName("recipeIngredients")
+    val recipeIngredients: List<RecipeIngredientJson>? = emptyList(),
+    @SerialName("recipeInstructions")
+    val recipeInstructions: List<RecipeInstructionJson>? = emptyList(),
+    @SerialName("nutrition")
+    val nutrition: RecipeNutritionJson? = null,
+    @SerialName("settings")
+    val settings: RecipeSettingsJson? = null,
+    @SerialName("assets")
+    val assets: List<RecipeAssetJson>? = emptyList(),
+    @SerialName("notes")
+    val notes: List<RecipeNoteJson>? = emptyList(),
+    @SerialName("extras")
+    val extras: String? = null,
+    @SerialName("comments")
+    val comments: List<CommentJson>? = emptyList(),
+) {
+    /**
+     * Models a comment for a recipe.
+     */
+    @Serializable
+    data class CommentJson(
+        @SerialName("recipeId")
+        val recipeId: String,
+        @SerialName("text")
+        val text: String,
+        @SerialName("id")
+        val id: String,
+        @SerialName("createdAt")
+        val createdAt: String,
+        @SerialName("updated_at")
+        val updatedAt: String,
+        @SerialName("userId")
+        val userId: String,
+        @SerialName("user")
+        val user: UserJson,
+    ) {
+        /**
+         * Models a recipe comment's user.
+         */
+        @Serializable
+        data class UserJson(
+            @SerialName("id")
+            val id: String,
+            @SerialName("username")
+            val username: String,
+            @SerialName("admin")
+            val admin: Boolean,
+            @SerialName("fullName")
+            val fullName: String,
+        )
+    }
+}

--- a/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/recipes/model/RecipeSettingsJson.kt
+++ b/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/recipes/model/RecipeSettingsJson.kt
@@ -1,0 +1,25 @@
+package com.saintpatrck.mealie.client.api.recipes.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Models settings for a recipe.
+ */
+@Serializable
+data class RecipeSettingsJson(
+    @SerialName("public")
+    val public: Boolean = false,
+    @SerialName("showNutrition")
+    val showNutrition: Boolean = false,
+    @SerialName("showAssets")
+    val showAssets: Boolean = false,
+    @SerialName("landscapeView")
+    val landscapeView: Boolean = false,
+    @SerialName("disableComments")
+    val disableComments: Boolean = true,
+    @SerialName("disableAmount")
+    val disableAmount: Boolean = true,
+    @SerialName("locked")
+    val locked: Boolean = false,
+)

--- a/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/recipes/model/TestScrapeUrlResponseJson.kt
+++ b/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/recipes/model/TestScrapeUrlResponseJson.kt
@@ -4,7 +4,7 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 /**
- * Models a recipe.
+ * Models a scraped recipe.
  */
 @Serializable
 data class TestScrapeUrlResponseJson(
@@ -33,14 +33,14 @@ data class TestScrapeUrlResponseJson(
     @SerialName("recipeIngredient")
     val recipeIngredient: List<String>?,
     @SerialName("recipeInstructions")
-    val recipeInstructions: List<RecipeInstruction>?,
+    val recipeInstructions: List<InstructionJson>?,
 ) {
 
     /**
-     * Models a recipe instruction.
+     * Models a scraped recipe's instruction.
      */
     @Serializable
-    data class RecipeInstruction(
+    data class InstructionJson(
         @SerialName("@type")
         val type: String,
         @SerialName("text")

--- a/client/src/commonTest/kotlin/com/saintpatrck/mealie/client/api/recipes/RecipesApiTest.kt
+++ b/client/src/commonTest/kotlin/com/saintpatrck/mealie/client/api/recipes/RecipesApiTest.kt
@@ -7,7 +7,7 @@ import com.saintpatrck.mealie.client.api.recipes.model.CreateRecipeFromHtmlOrJso
 import com.saintpatrck.mealie.client.api.recipes.model.CreateRecipeFromUrlBulkRequestJson
 import com.saintpatrck.mealie.client.api.recipes.model.CreateRecipeFromUrlBulkResponseJson
 import com.saintpatrck.mealie.client.api.recipes.model.CreateRecipeFromUrlRequestJson
-import com.saintpatrck.mealie.client.api.recipes.model.CreateRecipeRequestJson
+import com.saintpatrck.mealie.client.api.recipes.model.RecipeRequestJson
 import com.saintpatrck.mealie.client.api.recipes.model.TestScrapeUrlRequestJson
 import com.saintpatrck.mealie.client.api.recipes.model.TestScrapeUrlResponseJson
 import com.saintpatrck.mealie.client.api.util.RECIPE_JSON
@@ -167,11 +167,26 @@ class RecipesApiTest : BaseApiTest() {
         createTestMealieClient(responseJson = "mockSlug")
             .recipesApi
             .createRecipe(
-                recipe = createMockCreateRecipeRequestJson(),
+                recipe = createMockRecipeRequestJson(),
             )
             .also { response ->
                 assertEquals(
                     "mockSlug",
+                    response.getOrThrow(),
+                )
+            }
+    }
+
+    @Test
+    fun `updateRecipes should deserialize correctly`() = runTest {
+        createTestMealieClient(responseJson = "")
+            .recipesApi
+            .updateRecipes(
+                recipes = listOf(createMockRecipeRequestJson())
+            )
+            .also { response ->
+                assertEquals(
+                    Unit,
                     response.getOrThrow(),
                 )
             }
@@ -210,7 +225,6 @@ private const val CREATE_RECIPE_FROM_URL_BULK_JSON_RESPONSE = """
     "reportId": "f7f19343-4139-4e9f-a07e-a6fbfbe08b0f"
 }
 """
-
 private val PAGED_RECIPE_RESPONSE_JSON = """
 {
     "page": 1,
@@ -242,7 +256,7 @@ private fun createMockTestScrapeUrlResponseJson() = TestScrapeUrlResponseJson(
         "BEER BRINE",
     ),
     recipeInstructions = listOf(
-        TestScrapeUrlResponseJson.RecipeInstruction(
+        TestScrapeUrlResponseJson.InstructionJson(
             type = "HowToStep",
             text = "BEER BRINE"
         ),
@@ -259,17 +273,38 @@ private fun createMockPagedRecipeResponseJson() = PagedResponseJson(
     previous = "previous",
 )
 
-private fun createMockCreateRecipeRequestJson() = CreateRecipeRequestJson(
-    name = "mockName",
+private fun createMockRecipeRequestJson() = RecipeRequestJson(
+    id = "mockId",
+    userId = "mockUserId",
     householdId = "mockHouseholdId",
     groupId = "mockGroupId",
+    name = "mockName",
+    slug = "mockSlug",
+    image = "mockImage",
+    recipeServings = 1.0,
+    recipeYieldQuantity = 1.0,
     recipeYield = "mockRecipeYield",
     totalTime = "mockTotalTime",
     prepTime = "mockPrepTime",
     cookTime = "mockCookTime",
     performTime = "mockPerformTime",
+    description = "mockDescription",
     recipeCategory = emptyList(),
     tags = emptyList(),
     tools = emptyList(),
     rating = 0.0,
+    orgUrl = "mockOrgUrl",
+    dateAdded = "mockDateAdded",
+    dateUpdated = null,
+    createdAt = null,
+    updatedAt = null,
+    lastMade = null,
+    recipeIngredients = emptyList(),
+    recipeInstructions = emptyList(),
+    nutrition = null,
+    settings = null,
+    assets = emptyList(),
+    notes = emptyList(),
+    extras = null,
+    comments = emptyList(),
 )


### PR DESCRIPTION
This commit introduces the `updateRecipes` endpoint to the `RecipesApi` for bulk updating recipes.

It includes the following new data models:
- `RecipeRequestJson`: Represents the request body for updating a recipe.
- `RecipeIngredientJson`: Models a recipe ingredient, including `IngredientFoodJson`.
- `RecipeInstructionJson`: Models a recipe instruction.
- `RecipeNutritionJson`: Models nutritional information for a recipe.
- `RecipeSettingsJson`: Models settings for a recipe.
- `RecipeAssetJson`: Models an asset for a recipe.
- `RecipeNoteJson`: Models a note for a recipe.
- `IngredientUnitJson`: Models an ingredient unit of measure.
- `MultiPurposeLabelSummaryJson`: Models a multi-purpose label.

Additionally:
- `TestScrapeUrlResponseJson.RecipeInstruction` has been renamed to `TestScrapeUrlResponseJson.InstructionJson` for clarity.
- KDoc for `TestScrapeUrlResponseJson` and `TestScrapeUrlResponseJson.InstructionJson` has been updated.
- Tests for the new `updateRecipes` endpoint have been added in `RecipesApiTest`.