### PR TITLE
Upgrade Android Gradle Plugin to 8.10.1

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "8.10.0"
+agp = "8.10.1"
 
 androidMinSdk = "29"
 androidCompileSdk = "36"


### PR DESCRIPTION
This commit updates the Android Gradle Plugin version from 8.10.0 to 8.10.1.

[Release notes](https://developer.android.com/build/releases/gradle-plugin#android-gradle-plugin-8.10.1)