### PR TITLE
Add endpoint to update a recipe's `lastMade` date

### DIFF
--- a/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/recipes/RecipesApi.kt
+++ b/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/recipes/RecipesApi.kt
@@ -9,6 +9,7 @@ import com.saintpatrck.mealie.client.api.recipes.model.CreateRecipeFromHtmlOrJso
 import com.saintpatrck.mealie.client.api.recipes.model.CreateRecipeFromUrlBulkRequestJson
 import com.saintpatrck.mealie.client.api.recipes.model.CreateRecipeFromUrlBulkResponseJson
 import com.saintpatrck.mealie.client.api.recipes.model.CreateRecipeFromUrlRequestJson
+import com.saintpatrck.mealie.client.api.recipes.model.RecipeLastMadeJson
 import com.saintpatrck.mealie.client.api.recipes.model.RecipeRequestJson
 import com.saintpatrck.mealie.client.api.recipes.model.TestScrapeUrlRequestJson
 import com.saintpatrck.mealie.client.api.recipes.model.TestScrapeUrlResponseJson
@@ -225,6 +226,20 @@ interface RecipesApi {
     @DELETE("recipes/{slug}")
     suspend fun deleteRecipe(
         @Path("slug") slug: String,
+    ): MealieResponse<Unit>
+
+    /**
+     * Updates the `lastMade` date of a recipe.
+     *
+     * @param slug The slug or ID of the recipe to update.
+     * @param request The request body containing the new timestamp.
+     * @return A response indicating success.
+     */
+    @Headers("Content-Type: application/json")
+    @PATCH("recipes/{slug}/last-made")
+    suspend fun updateLastMade(
+        @Path("slug") slug: String,
+        @Body request: RecipeLastMadeJson,
     ): MealieResponse<Unit>
 
     /**

--- a/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/recipes/model/RecipeLastMadeJson.kt
+++ b/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/recipes/model/RecipeLastMadeJson.kt
@@ -1,0 +1,14 @@
+package com.saintpatrck.mealie.client.api.recipes.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlin.time.Instant
+
+/**
+ * Models a recipe last made date.
+ */
+@Serializable
+data class RecipeLastMadeJson(
+    @SerialName("timestamp")
+    val timestamp: Instant,
+)

--- a/client/src/commonTest/kotlin/com/saintpatrck/mealie/client/api/recipes/RecipesApiTest.kt
+++ b/client/src/commonTest/kotlin/com/saintpatrck/mealie/client/api/recipes/RecipesApiTest.kt
@@ -12,6 +12,7 @@ import com.saintpatrck.mealie.client.api.recipes.model.CreateRecipeFromUrlBulkRe
 import com.saintpatrck.mealie.client.api.recipes.model.CreateRecipeFromUrlRequestJson
 import com.saintpatrck.mealie.client.api.recipes.model.RecipeIngredientJson
 import com.saintpatrck.mealie.client.api.recipes.model.RecipeInstructionJson
+import com.saintpatrck.mealie.client.api.recipes.model.RecipeLastMadeJson
 import com.saintpatrck.mealie.client.api.recipes.model.RecipeNutritionJson
 import com.saintpatrck.mealie.client.api.recipes.model.RecipeRequestJson
 import com.saintpatrck.mealie.client.api.recipes.model.RecipeSettingsJson
@@ -268,6 +269,22 @@ class RecipesApiTest : BaseApiTest() {
             .recipesApi
             .deleteRecipe("mock-slug")
             .also { response ->
+                assertIs<Unit>(response.getOrThrow())
+            }
+    }
+
+    @Test
+    fun `updateLastMade should return unit`() = runTest {
+        val request = RecipeLastMadeJson(
+            timestamp = Instant.parse("2025-06-07T03:30:46.513510Z")
+        )
+
+        createTestMealieClient(responseJson = "")
+            .recipesApi
+            .updateLastMade(
+                slug = "mock-slug",
+                request = request,
+            ).also { response ->
                 assertIs<Unit>(response.getOrThrow())
             }
     }


### PR DESCRIPTION
This commit introduces the ability to update the `lastMade` date for a specific recipe.

A new `updateLastMade` suspend function has been added to the `RecipesApi` interface. This function sends a `PATCH` request to the `recipes/{slug}/last-made` endpoint to set the new timestamp.

To support this, the following changes were made:
- A new data class, `RecipeLastMadeJson`, was created to model the request body, containing a single `timestamp` field.
- A corresponding unit test, `updateLastMade should return unit`, was added to verify that the new endpoint call executes successfully and handles an empty success response.