### PR TITLE
Add endpoint to scrape a recipe image from a URL

### DIFF
--- a/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/recipes/RecipesApi.kt
+++ b/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/recipes/RecipesApi.kt
@@ -11,6 +11,7 @@ import com.saintpatrck.mealie.client.api.recipes.model.CreateRecipeFromUrlBulkRe
 import com.saintpatrck.mealie.client.api.recipes.model.CreateRecipeFromUrlRequestJson
 import com.saintpatrck.mealie.client.api.recipes.model.RecipeLastMadeJson
 import com.saintpatrck.mealie.client.api.recipes.model.RecipeRequestJson
+import com.saintpatrck.mealie.client.api.recipes.model.ScrapeImageUrlRequestJson
 import com.saintpatrck.mealie.client.api.recipes.model.TestScrapeUrlRequestJson
 import com.saintpatrck.mealie.client.api.recipes.model.TestScrapeUrlResponseJson
 import de.jensklingenberg.ktorfit.http.Body
@@ -295,4 +296,18 @@ interface RecipesApi {
         @Query("includeToolsOnHand")
         includesToolsOnHand: Boolean = true,
     ): MealieResponse<PagedResponseJson<RecipeJson>>
+
+    /**
+     * Scrapes an image from a URL and sets it as the recipe's image.
+     *
+     * @param slug The slug or ID of the recipe to update.
+     * @param request The request body containing the URL of the image to scrape.
+     * @return A response indicating success.
+     */
+    @Headers("Content-Type: application/json")
+    @POST("recipes/{slug}/image")
+    suspend fun scrapeImageUrl(
+        @Path("slug") slug: String,
+        @Body request: ScrapeImageUrlRequestJson,
+    ): MealieResponse<Unit>
 }

--- a/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/recipes/model/ScrapeImageUrlRequestJson.kt
+++ b/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/recipes/model/ScrapeImageUrlRequestJson.kt
@@ -1,0 +1,22 @@
+package com.saintpatrck.mealie.client.api.recipes.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+
+/**
+ * A data class representing the JSON body for a request to scrape a recipe from a URL.
+ *
+ * @property includeTags Whether to include tags from the scraped recipe.
+ * @property url The URL of the recipe to scrape.
+ */
+@Serializable
+data class ScrapeImageUrlRequestJson(
+    /** Whether to include tags from the scraped recipe. */
+    @SerialName("includeTags")
+    val includeTags: Boolean,
+
+    /** The URL of the image to scrape. */
+    @SerialName("url")
+    val url: String,
+)

--- a/client/src/commonTest/kotlin/com/saintpatrck/mealie/client/api/recipes/RecipesApiTest.kt
+++ b/client/src/commonTest/kotlin/com/saintpatrck/mealie/client/api/recipes/RecipesApiTest.kt
@@ -16,6 +16,7 @@ import com.saintpatrck.mealie.client.api.recipes.model.RecipeLastMadeJson
 import com.saintpatrck.mealie.client.api.recipes.model.RecipeNutritionJson
 import com.saintpatrck.mealie.client.api.recipes.model.RecipeRequestJson
 import com.saintpatrck.mealie.client.api.recipes.model.RecipeSettingsJson
+import com.saintpatrck.mealie.client.api.recipes.model.ScrapeImageUrlRequestJson
 import com.saintpatrck.mealie.client.api.recipes.model.TestScrapeUrlRequestJson
 import com.saintpatrck.mealie.client.api.recipes.model.TestScrapeUrlResponseJson
 import com.saintpatrck.mealie.client.api.util.RECIPE_JSON
@@ -330,6 +331,25 @@ class RecipesApiTest : BaseApiTest() {
                     it.getOrThrow(),
                 )
             }
+    }
+
+    @Test
+    fun `scrapeImageUrl should construct url and deserialize response correctly`() = runTest {
+        createTestMealieClient(responseJson = "") {
+            assertEquals(
+                "http://localhost:9925/recipes/mock-slug/image",
+                it.url.toString()
+            )
+        }
+            .recipesApi
+            .scrapeImageUrl(
+                "mock-slug",
+                request = ScrapeImageUrlRequestJson(
+                    includeTags = true,
+                    url = "mockUrl",
+                ),
+            )
+            .also { assertIs<Unit>(it.getOrThrow()) }
     }
 }
 


### PR DESCRIPTION
This commit introduces functionality to scrape an image from a given URL and assign it as the image for a specific recipe.

A new `scrapeImageUrl` suspend function has been added to the `RecipesApi` interface. This function sends a `POST` request to the `recipes/{slug}/image` endpoint.

To support this, the following changes were made:
- A new data class, `ScrapeImageUrlRequestJson`, was created to model the request body, which includes the `url` of the image to scrape and an `includeTags` flag.
- A corresponding unit test, `scrapeImageUrl should construct url and deserialize response correctly`, was added to verify that the request is constructed correctly and that an empty success response is handled properly.