### PR TITLE
Add endpoint to update a recipe's image

### DIFF
--- a/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/recipes/RecipesApi.kt
+++ b/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/recipes/RecipesApi.kt
@@ -14,6 +14,8 @@ import com.saintpatrck.mealie.client.api.recipes.model.RecipeRequestJson
 import com.saintpatrck.mealie.client.api.recipes.model.ScrapeImageUrlRequestJson
 import com.saintpatrck.mealie.client.api.recipes.model.TestScrapeUrlRequestJson
 import com.saintpatrck.mealie.client.api.recipes.model.TestScrapeUrlResponseJson
+import com.saintpatrck.mealie.client.api.recipes.model.UpdateRecipeImageRequest
+import com.saintpatrck.mealie.client.api.recipes.model.UpdateRecipeImageResponse
 import de.jensklingenberg.ktorfit.http.Body
 import de.jensklingenberg.ktorfit.http.DELETE
 import de.jensklingenberg.ktorfit.http.GET
@@ -310,4 +312,19 @@ interface RecipesApi {
         @Path("slug") slug: String,
         @Body request: ScrapeImageUrlRequestJson,
     ): MealieResponse<Unit>
+
+    /**
+     * Updates the image of a recipe.
+     *
+     * @param slug The slug or ID of the recipe to update.
+     * @param image The request containing the new image data.
+     * @return The updated recipe data.
+     */
+    @Headers("Content-Type: application/json")
+    @PUT("recipes/{slug}/image")
+    suspend fun updateImage(
+        @Path("slug") slug: String,
+        @Body image: UpdateRecipeImageRequest,
+    ): MealieResponse<UpdateRecipeImageResponse>
+
 }

--- a/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/recipes/model/UpdateRecipeImageRequest.kt
+++ b/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/recipes/model/UpdateRecipeImageRequest.kt
@@ -1,0 +1,25 @@
+package com.saintpatrck.mealie.client.api.recipes.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * A data class representing the request body for updating a recipe's image.
+ *
+ * @property image A base64 encoded string of the image.
+ * @property extensions The file extension of the image (e.g., "jpg", "png").
+ */
+@Serializable
+data class UpdateRecipeImageRequest(
+    /**
+     * A base64 encoded string of the image.
+     */
+    @SerialName("image")
+    val image: String,
+
+    /**
+     * The file extension of the image.
+     */
+    @SerialName("extension")
+    val extension: String
+)

--- a/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/recipes/model/UpdateRecipeImageResponse.kt
+++ b/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/recipes/model/UpdateRecipeImageResponse.kt
@@ -1,0 +1,20 @@
+package com.saintpatrck.mealie.client.api.recipes.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+
+/**
+ * Represents the response received after successfully updating a recipe's image.
+ *
+ * @property image The filename of the newly uploaded image.
+ */
+@Serializable
+data class UpdateRecipeImageResponse(
+
+    /**
+     * Binary string representation of the image.
+     */
+    @SerialName("image")
+    val image: String
+)

--- a/client/src/commonTest/kotlin/com/saintpatrck/mealie/client/api/recipes/RecipesApiTest.kt
+++ b/client/src/commonTest/kotlin/com/saintpatrck/mealie/client/api/recipes/RecipesApiTest.kt
@@ -19,6 +19,8 @@ import com.saintpatrck.mealie.client.api.recipes.model.RecipeSettingsJson
 import com.saintpatrck.mealie.client.api.recipes.model.ScrapeImageUrlRequestJson
 import com.saintpatrck.mealie.client.api.recipes.model.TestScrapeUrlRequestJson
 import com.saintpatrck.mealie.client.api.recipes.model.TestScrapeUrlResponseJson
+import com.saintpatrck.mealie.client.api.recipes.model.UpdateRecipeImageRequest
+import com.saintpatrck.mealie.client.api.recipes.model.UpdateRecipeImageResponse
 import com.saintpatrck.mealie.client.api.util.RECIPE_JSON
 import com.saintpatrck.mealie.client.api.util.RECIPE_LIST_JSON
 import com.saintpatrck.mealie.client.api.util.createMockRecipeJson
@@ -351,6 +353,32 @@ class RecipesApiTest : BaseApiTest() {
             )
             .also { assertIs<Unit>(it.getOrThrow()) }
     }
+
+    @Test
+    fun `updateImage should construct url and deserialize response correctly`() = runTest {
+        createTestMealieClient(responseJson = UPDATE_RECIPE_IMAGE_RESPONSE_JSON) {
+            assertEquals(
+                "http://localhost:9925/recipes/mock-slug/image",
+                it.url.toString()
+            )
+        }
+            .recipesApi
+            .updateImage(
+                slug = "mock-slug",
+                image = UpdateRecipeImageRequest(
+                    image = "mockImage",
+                    extension = "jpg"
+                ),
+            )
+            .also {
+                assertEquals(
+                    UpdateRecipeImageResponse(
+                        image = "ABCDEF0123456789"
+                    ),
+                    it.getOrThrow()
+                )
+            }
+    }
 }
 
 private val TEST_SCRAPE_URL_RESPONSE_JSON = """
@@ -398,6 +426,13 @@ private val PAGED_RECIPE_RESPONSE_JSON = """
     ],
     "next": "next",
     "previous": "previous"
+}
+"""
+    .trimIndent()
+
+private val UPDATE_RECIPE_IMAGE_RESPONSE_JSON = """
+{
+    "image": "ABCDEF0123456789"
 }
 """
     .trimIndent()


### PR DESCRIPTION
This commit introduces the functionality to update the image for a specific recipe.

A new `updateImage` suspend function has been added to the `RecipesApi` interface. This function sends a `PUT` request to the `recipes/{slug}/image` endpoint to upload a new image for the recipe identified by its slug.

To support this, the following changes were made:
- The `UpdateRecipeImageRequest` data class was created to model the request body, which includes the base64-encoded image and its file extension.
- The `UpdateRecipeImageResponse` data class was created to handle the response, which contains the base64-encoded image.