### PR TITLE
Add endpoint to upload a recipe asset

### DIFF
--- a/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/recipes/RecipesApi.kt
+++ b/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/recipes/RecipesApi.kt
@@ -16,6 +16,8 @@ import com.saintpatrck.mealie.client.api.recipes.model.TestScrapeUrlRequestJson
 import com.saintpatrck.mealie.client.api.recipes.model.TestScrapeUrlResponseJson
 import com.saintpatrck.mealie.client.api.recipes.model.UpdateRecipeImageRequest
 import com.saintpatrck.mealie.client.api.recipes.model.UpdateRecipeImageResponse
+import com.saintpatrck.mealie.client.api.recipes.model.UploadAssetRequestJson
+import com.saintpatrck.mealie.client.api.recipes.model.UploadAssetResponseJson
 import de.jensklingenberg.ktorfit.http.Body
 import de.jensklingenberg.ktorfit.http.DELETE
 import de.jensklingenberg.ktorfit.http.GET
@@ -327,4 +329,18 @@ interface RecipesApi {
         @Body image: UpdateRecipeImageRequest,
     ): MealieResponse<UpdateRecipeImageResponse>
 
+
+    /**
+     * Uploads an asset for a recipe.
+     *
+     * @param slug The slug or ID of the recipe.
+     * @param request The request body containing the asset details.
+     * @return A response containing information about the uploaded asset.
+     */
+    @Headers("Content-Type: application/json")
+    @POST("recipes/{slug}/assets")
+    suspend fun uploadAsset(
+        @Path("slug") slug: String,
+        @Body request: UploadAssetRequestJson,
+    ) : MealieResponse<UploadAssetResponseJson>
 }

--- a/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/recipes/model/UploadAssetRequestJson.kt
+++ b/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/recipes/model/UploadAssetRequestJson.kt
@@ -1,0 +1,36 @@
+package com.saintpatrck.mealie.client.api.recipes.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Represents the JSON body for an asset upload request.
+ *
+ * @property name The name of the asset.
+ * @property icon The icon associated with the asset.
+ * @property extension The file extension of the asset (e.g., "jpg", "png").
+ * @property file The base64 encoded string of the file content.
+ */
+@Serializable
+data class UploadAssetRequestJson(
+    /**
+     * The name of the asset.
+     */
+    @SerialName("name")
+    val name: String,
+    /**
+     * The icon associated with the asset.
+     */
+    @SerialName("icon")
+    val icon: String,
+    /**
+     * The file extension of the asset (e.g., "jpg", "png").
+     */
+    @SerialName("extension")
+    val extension: String,
+    /**
+     * The base64 encoded string of the file content.
+     */
+    @SerialName("file")
+    val file: String,
+)

--- a/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/recipes/model/UploadAssetResponseJson.kt
+++ b/client/src/commonMain/kotlin/com/saintpatrck/mealie/client/api/recipes/model/UploadAssetResponseJson.kt
@@ -1,0 +1,26 @@
+package com.saintpatrck.mealie.client.api.recipes.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Represents the response from the server after uploading a recipe asset (e.g., an image).
+ *
+ * @property name The original name of the uploaded file.
+ * @property fileName The new, processed filename on the server.
+ */
+@Serializable
+data class UploadAssetResponseJson(
+
+    /**
+     * The original name of the uploaded file.
+     */
+    @SerialName("name")
+    val name: String,
+
+    /**
+     * The new, processed filename on the server.
+     */
+    @SerialName("fileName")
+    val fileName: String,
+)

--- a/client/src/commonTest/kotlin/com/saintpatrck/mealie/client/api/recipes/RecipesApiTest.kt
+++ b/client/src/commonTest/kotlin/com/saintpatrck/mealie/client/api/recipes/RecipesApiTest.kt
@@ -21,6 +21,8 @@ import com.saintpatrck.mealie.client.api.recipes.model.TestScrapeUrlRequestJson
 import com.saintpatrck.mealie.client.api.recipes.model.TestScrapeUrlResponseJson
 import com.saintpatrck.mealie.client.api.recipes.model.UpdateRecipeImageRequest
 import com.saintpatrck.mealie.client.api.recipes.model.UpdateRecipeImageResponse
+import com.saintpatrck.mealie.client.api.recipes.model.UploadAssetRequestJson
+import com.saintpatrck.mealie.client.api.recipes.model.UploadAssetResponseJson
 import com.saintpatrck.mealie.client.api.util.RECIPE_JSON
 import com.saintpatrck.mealie.client.api.util.RECIPE_LIST_JSON
 import com.saintpatrck.mealie.client.api.util.createMockRecipeJson
@@ -379,6 +381,35 @@ class RecipesApiTest : BaseApiTest() {
                 )
             }
     }
+
+    @Test
+    fun `uploadAsset should construct url and deserialize response correctly`() = runTest {
+        createTestMealieClient(responseJson = UPLOAD_ASSET_RESPONSE_JSON) {
+            assertEquals(
+                "http://localhost:9925/recipes/mock-slug/assets",
+                it.url.toString()
+            )
+        }
+            .recipesApi
+            .uploadAsset(
+                slug = "mock-slug",
+                request = UploadAssetRequestJson(
+                    name = "mockName",
+                    icon = "mockIcon",
+                    extension = "jpg",
+                    file = "ABCDEF-123456789",
+                ),
+            )
+            .also {
+                assertEquals(
+                    UploadAssetResponseJson(
+                        name = "mockName",
+                        fileName = "mockFileName"
+                    ),
+                    it.getOrThrow(),
+                )
+            }
+    }
 }
 
 private val TEST_SCRAPE_URL_RESPONSE_JSON = """
@@ -436,6 +467,14 @@ private val UPDATE_RECIPE_IMAGE_RESPONSE_JSON = """
 }
 """
     .trimIndent()
+
+private val UPLOAD_ASSET_RESPONSE_JSON = """
+{
+    "name": "mockName",
+    "icon": "mockIcon",
+    "fileName": "mockFileName"
+}
+""".trimIndent()
 
 private fun createMockTestScrapeUrlResponseJson() = TestScrapeUrlResponseJson(
     context = "https://schema.org/",


### PR DESCRIPTION
This commit introduces the functionality to upload an asset for a specific recipe.

A new `uploadAsset` suspend function has been added to the `RecipesApi` interface. This function sends a `POST` request to the `recipes/{slug}/assets` endpoint to upload the asset file.

To support this, the following changes were made:
- The `UploadAssetRequestJson` data class was created to model the request body, which includes the asset's name, icon, extension, and the base64 encoded file content.
- The `UploadAssetResponseJson` data class was created to model the successful response from the server.
- A new unit test, `uploadAsset should construct url and deserialize response correctly`, was added to verify that the request URL is correctly constructed and that the response is deserialized properly.